### PR TITLE
feat: add Docker Compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,16 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/context0-server ./cmd/server
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/context0-consolidate ./cmd/consolidate
 
-# Stage 2: Runtime (distroless)
-FROM gcr.io/distroless/static-debian12:nonroot
+# Stage 2: Runtime (alpine for healthcheck support)
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates wget
+RUN adduser -D -u 1000 context0
 
 COPY --from=builder /bin/context0-server /usr/local/bin/context0-server
 COPY --from=builder /bin/context0-consolidate /usr/local/bin/context0-consolidate
 
-USER nonroot:nonroot
+USER context0
 
 EXPOSE 50051 8080
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,104 @@
+# Context0 — Local Development with Docker Compose
+#
+# Start everything:   docker compose up
+# Start in background: docker compose up -d
+# Stop:               docker compose down
+# Stop + delete data: docker compose down -v
+#
+# Services:
+#   - postgres:  PostgreSQL 18 + Apache AGE + pgvector (port 5432)
+#   - api:       Context0 gRPC + REST API (ports 50051, 8080)
+#   - web:       React web UI (port 3000)
+#
+# Access:
+#   - Web UI:    http://localhost:3000
+#   - REST API:  http://localhost:8080/v1/health
+#   - gRPC:      localhost:50051
+
+services:
+  # ── PostgreSQL + Apache AGE + pgvector ──────────────────
+  postgres:
+    build:
+      context: ./docker/postgres-age-vector
+    container_name: context0-postgres
+    environment:
+      POSTGRES_DB: context0
+      POSTGRES_USER: context0
+      POSTGRES_PASSWORD: context0
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U context0"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── Context0 API Server ─────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: context0-api
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      CONTEXT0_DATABASE_URL: "postgres://context0:context0@postgres:5432/context0?sslmode=disable"
+      CONTEXT0_GRPC_PORT: "50051"
+      CONTEXT0_HTTP_PORT: "8080"
+      CONTEXT0_API_KEYS: "ctx0_dev_key_1,ctx0_dev_key_2"
+      CONTEXT0_EMBEDDING_PROVIDER: "bag-of-words"
+      CONTEXT0_LLM_PROVIDER: "rule-based"
+      # To use Ollama (if running on host):
+      # CONTEXT0_EMBEDDING_PROVIDER: ollama
+      # CONTEXT0_EMBEDDING_BASE_URL: http://host.docker.internal:11434
+      # CONTEXT0_EMBEDDING_MODEL: nomic-embed-text
+    ports:
+      - "8080:8080"
+      - "50051:50051"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/v1/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  # ── Web UI ──────────────────────────────────────────────
+  web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    container_name: context0-web
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-3000}:80"
+    restart: unless-stopped
+
+  # ── Consolidation (one-off job, run manually) ───────────
+  # Run: docker compose run --rm consolidation
+  consolidation:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: context0-consolidation
+    entrypoint: ["context0-consolidate"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      CONTEXT0_DATABASE_URL: "postgres://context0:context0@postgres:5432/context0?sslmode=disable"
+      CONSOLIDATION_DECAY_HALF_LIFE_DAYS: "30"
+      CONSOLIDATION_STALE_THRESHOLD: "0.1"
+      CONSOLIDATION_PRUNE_AGE_DAYS: "30"
+      CONSOLIDATION_DRY_RUN: "false"
+    profiles:
+      - tools  # Only runs when explicitly invoked
+
+volumes:
+  pgdata:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,5 +10,8 @@ RUN pnpm build
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+# nginx:alpine auto-runs envsubst on /etc/nginx/templates/*.template at startup
+ENV API_HOST=api
+ENV API_PORT=8080
 EXPOSE 80

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: serve index.html for all non-file routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to the Context0 backend
+    location /v1/ {
+        proxy_pass http://${API_HOST}:${API_PORT};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary

`docker compose up` — one command to run Context0 locally without Kubernetes.

## Services

| Service | Port | Purpose |
|---------|------|---------|
| postgres | 5432 | PostgreSQL 18 + Apache AGE + pgvector |
| api | 8080, 50051 | Context0 REST + gRPC API |
| web | 3000 | React web UI (nginx proxy) |

## Usage

```bash
docker compose up        # start everything
docker compose up -d     # background mode
docker compose down -v   # stop + delete data
```

## Test Plan

- [x] All 3 services start and pass healthchecks
- [x] API returns health OK
- [x] Web UI loads and proxies API requests
- [x] Store memory via REST API works