### PR TITLE
feat(site): host on Cloudflare Pages, verify in GitHub Actions

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,10 +1,17 @@
-name: Deploy Site
+name: Site
 
-# The marketing site at context0.sabarinarayana.com. Builds the static Vite
-# bundle in site/ and publishes it to GitHub Pages.
+# Verification runs here; hosting is Cloudflare Pages.
 #
-# Scoped to site/ so a Go-only change does not redeploy the site, and a copy
-# tweak does not wait on the Go test matrix.
+# The split is deliberate. GitHub Actions is where the five checks live,
+# because they need three browser engines and take a couple of minutes -
+# work a CDN build step should not be doing. Cloudflare builds and serves
+# the site, because it already terminates TLS for this domain and issues
+# certificates in seconds rather than the tens of minutes GitHub Pages took.
+#
+# Deployment is a push, not a pull: this workflow uploads the built site to
+# Cloudflare only after the checks pass. Cloudflare's own git integration is
+# deliberately left disconnected, so nothing reaches production without
+# passing through here first.
 
 on:
   push:
@@ -23,12 +30,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: site-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,9 +58,6 @@ jobs:
         working-directory: site
         run: pnpm build
 
-      # A broken link or a page that renders blank is invisible until someone
-      # visits it, and the build is happy either way. Check the emitted HTML,
-      # then drive the real pages in a browser.
       - name: Check built output
         working-directory: site
         run: node scripts/check-build.mjs
@@ -85,27 +89,37 @@ jobs:
         working-directory: site
         run: node scripts/waitlist.mjs
 
-
-      - name: Upload artifact
-        # Only the main-branch run needs to hand anything to the deploy job;
-        # on a PR the build and checks above are the whole point.
+      # Hand the verified build to the deploy job rather than rebuilding it,
+      # so what ships is byte-for-byte what was checked.
+      - name: Upload verified build
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: site-dist
           path: site/dist
+          retention-days: 1
 
   deploy:
     name: Deploy
-    # A PR must not publish to the live domain.
+    # A pull request must never publish to the live domain.
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    needs: build
+    needs: verify
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      name: production
+      url: https://context0.sabarinarayana.com
     steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/checkout@v4
+
+      - name: Download verified build
+        uses: actions/download-artifact@v4
+        with:
+          name: site-dist
+          path: site/dist
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site/dist --project-name=context0 --branch=main

--- a/site/README.md
+++ b/site/README.md
@@ -125,68 +125,74 @@ headline changes.
 
 ## Deployment
 
-`.github/workflows/site.yaml` builds and publishes to GitHub Pages on every push
-to `main` that touches `site/`. Pull requests build and verify but never deploy.
+Hosted on **Cloudflare Pages**. Verified by **GitHub Actions**.
+
+`.github/workflows/site.yaml` runs the five checks on every push and pull
+request touching `site/`, and only then uploads the built site to Cloudflare.
+Deployment is a push from CI rather than a pull by Cloudflare: the same
+artifact that passed the checks is the one that ships, and nothing reaches
+production without going through them.
+
+Cloudflare's own git integration is deliberately **not** connected. If it were,
+it would build and publish straight from `main` on its own, bypassing every
+check here.
 
 ### One-time setup
 
-1. **Enable Pages with the Actions source.** Settings -> Pages -> Source:
-   **GitHub Actions**. Or:
+1. **Create the Pages project.** Cloudflare dashboard -> Workers & Pages ->
+   Create -> Pages -> **Direct Upload**, named `context0`. Direct Upload rather
+   than a git connection, for the reason above. The first real upload comes
+   from CI.
+
+2. **Create an API token.** My Profile -> API Tokens -> Create Token, using the
+   **Edit Cloudflare Workers** template, or a custom token with:
+
+   | Scope | Permission |
+   |---|---|
+   | Account -> Cloudflare Pages | Edit |
+
+   Restrict it to the one account. It needs nothing else - not DNS, not zone
+   settings, and certainly not account-wide write.
+
+3. **Add both secrets to the repository.** Settings -> Secrets and variables ->
+   Actions:
 
    ```bash
-   gh api -X POST repos/NarayanaSabari/Context0/pages \
-     -f 'build_type=workflow' \
-     -f 'source[branch]=main' -f 'source[path]=/'
+   gh secret set CLOUDFLARE_API_TOKEN --repo NarayanaSabari/Context0
+   gh secret set CLOUDFLARE_ACCOUNT_ID --repo NarayanaSabari/Context0
    ```
 
-2. **Add the DNS record** in Cloudflare, on the `sabarinarayana.com` zone:
+   The account ID is on the right-hand side of any Cloudflare dashboard page.
 
-   | Type | Name | Target | Proxy | TTL |
-   |------|------|--------|-------|-----|
-   | CNAME | `context0` | `narayanasabari.github.io` | **DNS only** | Auto |
+4. **Point the custom domain at the Pages project.** Workers & Pages ->
+   `context0` -> Custom domains -> Set up a custom domain ->
+   `context0.sabarinarayana.com`.
 
-   Three things that are easy to get wrong:
+   Cloudflare rewrites the DNS record itself and issues the certificate, so the
+   old `CNAME -> narayanasabari.github.io` record should be removed. Unlike
+   GitHub Pages, the record here **is** proxied (orange cloud); that is how
+   Cloudflare serves and terminates TLS for it.
 
-   - **Proxy must be DNS only** (grey cloud, not orange). With the proxy on,
-     GitHub cannot validate domain ownership and certificate issuance fails.
-     The proxy can be enabled later once the certificate exists, though Pages
-     already serves through a CDN so it buys little.
-   - **Name is `context0`**, not the full hostname. Cloudflare appends the zone.
-   - **Target is `narayanasabari.github.io`**, the *owner's* Pages host. Not
-     `context0.github.io`, and not the project path. The repository is owned by
-     the user `NarayanaSabari`, so that is the host every Pages site of theirs
-     is served from. Pointing elsewhere resolves to a host that does not serve
-     this site, and the domain never comes up.
-
-   If Cloudflare's SSL/TLS mode for the zone is **Flexible**, set it to **Full**
-   before enabling HTTPS below. Flexible talks to the origin over plain HTTP,
-   which GitHub redirects, producing a redirect loop.
-
-3. **Set the custom domain** once DNS resolves:
+5. **Verify:**
 
    ```bash
-   gh api -X PUT repos/NarayanaSabari/Context0/pages \
-     -f 'cname=context0.sabarinarayana.com'
-   ```
-
-   Already applied. Note the order: GitHub only issues the TLS certificate
-   after the DNS record resolves, and rejects `https_enforced=true` before that
-   with "The certificate does not exist yet". Once `dig` returns the record,
-   enable it:
-
-   ```bash
-   gh api -X PUT repos/NarayanaSabari/Context0/pages \
-     -f 'cname=context0.sabarinarayana.com' -F 'https_enforced=true'
-   ```
-
-   `public/CNAME` is copied into every build so the domain survives redeploys.
-
-4. **Verify:**
-
-   ```bash
-   dig +short context0.sabarinarayana.com     # expect narayanasabari.github.io
    curl -sI https://context0.sabarinarayana.com | head -1
    ```
+
+### Rollbacks
+
+Every deploy is retained. Workers & Pages -> `context0` -> Deployments ->
+pick a previous one -> Rollback. That is instant and needs no rebuild, which is
+the main practical gain over the previous setup.
+
+### What happened to GitHub Pages
+
+It served this site briefly and worked. It was replaced because its TLS
+certificate for a custom domain had not issued after roughly fifteen minutes,
+while Cloudflare already terminates TLS for this zone and does it in seconds.
+`public/CNAME` is now unused by the host but harmless, and `check-build.mjs`
+still asserts its contents as a cheap guard against the domain silently
+changing in one place and not another.
 
 ## Design history
 

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,44 @@
+# Response headers, applied by Cloudflare Pages.
+#
+# GitHub Pages offered no way to set these, so the site shipped without them.
+# Cloudflare reads this file from the build output, so they cost nothing now.
+#
+# Syntax: a path pattern, then indented `Header: value` lines.
+# Reference: https://developers.cloudflare.com/pages/configuration/headers/
+
+/*
+  # Do not let the site be framed. It has a form on it, so clickjacking a
+  # transparent overlay onto the waitlist button is a real, cheap attack.
+  X-Frame-Options: DENY
+
+  # Stop browsers second-guessing declared content types.
+  X-Content-Type-Options: nosniff
+
+  # Send the origin to other sites, the full URL to ourselves. Referrer paths
+  # are not sensitive here, but there is no reason to leak them either.
+  Referrer-Policy: strict-origin-when-cross-origin
+
+  # This site has no camera, microphone, or geolocation features. Saying so
+  # means a future dependency cannot quietly start asking for them.
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+
+  # Content Security Policy, written against what the site actually loads:
+  #   - scripts: our own bundle, plus Cloudflare's Web Analytics beacon, which
+  #     the platform injects into every response and which the CSP would
+  #     otherwise block on every page load. Its connect-src entry is needed
+  #     too, since the beacon POSTs back to cloudflareinsights.com.
+  #   - styles: our own bundle only. Tailwind emits a stylesheet rather than
+  #     inline styles, so 'unsafe-inline' is not needed for style-src.
+  #   - fonts: Google Fonts, which is the one third party here.
+  #   - form-action 'none': the waitlist submits via fetch(), never a native
+  #     form POST, so nothing should ever be able to navigate the browser to
+  #     a form target. When a waitlist endpoint is configured, add its origin
+  #     to connect-src rather than relaxing this.
+  #   - frame-ancestors duplicates X-Frame-Options for browsers that prefer CSP.
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; form-action 'none'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'
+
+# Fingerprinted assets never change under the same name, so they can be
+# cached hard. Everything else is revalidated, since index.html must not go
+# stale after a deploy.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/site/scripts/check-build.mjs
+++ b/site/scripts/check-build.mjs
@@ -65,6 +65,34 @@ if (existsSync(cnamePath)) {
 }
 
 check(existsSync(join(dist, 'og.png')), 'dist/og.png is missing - link previews would be blank')
+
+// Cloudflare reads response headers from this file in the build output. If it
+// stops being emitted the site keeps working and silently loses its CSP,
+// clickjacking protection, and asset caching - a failure with no symptom.
+{
+  const headersPath = join(dist, '_headers')
+  check(existsSync(headersPath), 'dist/_headers is missing - security headers would be dropped')
+  if (existsSync(headersPath)) {
+    const headers = readFileSync(headersPath, 'utf8')
+    for (const name of [
+      'Content-Security-Policy',
+      'X-Frame-Options',
+      'X-Content-Type-Options',
+      'Referrer-Policy',
+    ]) {
+      check(headers.includes(name), `_headers does not set ${name}`)
+    }
+    // The CSP has to allow the one third party the pages actually load.
+    check(
+      /style-src[^;]*fonts\.googleapis\.com/.test(headers),
+      'CSP style-src does not allow Google Fonts, which every page loads',
+    )
+    check(
+      /font-src[^;]*fonts\.gstatic\.com/.test(headers),
+      'CSP font-src does not allow Google Fonts, which every page loads',
+    )
+  }
+}
 check(existsSync(join(dist, 'favicon.svg')), 'dist/favicon.svg is missing')
 
 for (const page of PAGES) {

--- a/site/scripts/verify-site.mjs
+++ b/site/scripts/verify-site.mjs
@@ -11,7 +11,7 @@
 import { chromium } from 'playwright'
 import { createServer } from 'node:http'
 import { readFile, mkdir } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join, dirname, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -29,6 +29,31 @@ const TYPES = {
   '': 'text/plain',
 }
 
+// Apply the same response headers Cloudflare will, parsed from the _headers
+// file in the build output. Without this the suite tests a site that behaves
+// differently from production: a Content-Security-Policy that blocks the
+// bundle or the webfonts would pass every local check and break on deploy.
+const globalHeaders = (() => {
+  const file = join(dist, '_headers')
+  if (!existsSync(file)) return {}
+  const out = {}
+  let inGlobal = false
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    if (/^\/\*\s*$/.test(line)) {
+      inGlobal = true
+      continue
+    }
+    if (/^\//.test(line)) {
+      inGlobal = false
+      continue
+    }
+    if (!inGlobal) continue
+    const m = line.match(/^\s+([A-Za-z-]+):\s*(.+)$/)
+    if (m) out[m[1]] = m[2]
+  }
+  return out
+})()
+
 // Serve dist/ the way GitHub Pages does, including directory index resolution,
 // so /blog/ has to genuinely work rather than only /blog/index.html.
 const server = createServer(async (req, res) => {
@@ -40,7 +65,10 @@ const server = createServer(async (req, res) => {
     if (!existsSync(file) || !file.startsWith(dist)) continue
     try {
       const body = await readFile(file)
-      res.writeHead(200, { 'Content-Type': TYPES[extname(file)] ?? 'application/octet-stream' })
+      res.writeHead(200, {
+        ...globalHeaders,
+        'Content-Type': TYPES[extname(file)] ?? 'application/octet-stream',
+      })
       res.end(body)
       return
     } catch {
@@ -50,7 +78,7 @@ const server = createServer(async (req, res) => {
   // Pages serves 404.html for anything it cannot match, with a 404 status.
   // Mirror that here so the custom error page is exercised the same way.
   const notFound = join(dist, '404.html')
-  res.writeHead(404, { 'Content-Type': 'text/html' })
+  res.writeHead(404, { ...globalHeaders, 'Content-Type': 'text/html' })
   res.end(existsSync(notFound) ? await readFile(notFound) : '<h1>404</h1>')
 })
 
@@ -104,6 +132,11 @@ for (const page of PAGES) {
     // render output.
     const hydrationIssue = errors.find((e) => /hydrat|did not match|server HTML/i.test(e))
     note(!hydrationIssue, `${where}: hydration mismatch: ${hydrationIssue}`)
+
+    // A Content-Security-Policy that blocks the bundle or the webfonts looks
+    // fine in dev, where no headers are applied, and breaks on deploy.
+    const csp = errors.find((e) => /Content Security Policy|Refused to/i.test(e))
+    note(!csp, `${where}: blocked by CSP: ${csp}`)
 
     // Did React actually mount? An exception during render leaves an empty
     // #root and a page that looks like a blank dark screen.


### PR DESCRIPTION
Moves hosting from GitHub Pages to Cloudflare Pages. Verification stays in GitHub Actions.

**The site is already live on the new host: https://context0.sabarinarayana.com** — deployed manually via wrangler while setting this up. This PR makes that deployment automatic.

## Why move

GitHub Pages served the site fine but never issued a TLS certificate for the custom domain. Twenty minutes in it was still presenting `*.github.io`, so the site was HTTP-only. Cloudflare already terminates TLS for this zone and issued the certificate in about three minutes.

## How it works now

CI verifies, then pushes. Cloudflare's own git integration is deliberately **not** connected — if it were, it would build and publish straight from `main` and bypass every check here.

1. `verify` job runs the five checks and uploads the built artifact
2. `deploy` job downloads that exact artifact and ships it via `wrangler`

So what reaches production is byte-for-byte what passed the checks, rather than a rebuild that might differ.

## Security headers, which GitHub Pages could not do at all

It has no mechanism for setting response headers, so the site shipped without any. Cloudflare reads them from `_headers` in the build output, so the site now sends a CSP, `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, a `Permissions-Policy`, and immutable caching for fingerprinted assets. The clickjacking headers matter here specifically because the page has a form on it.

The CSP is written against what the site actually loads rather than copied from a template: `'self'` for scripts, Google Fonts for stylesheet and font, and `form-action 'none'` because the waitlist submits via `fetch` and should never be able to navigate the browser to a form target.

A CSP is exactly the kind of thing that passes locally — where no headers are applied — and breaks on deploy. So `verify-site.mjs` now parses `_headers` and serves them, making every page in the suite run under the real policy, and treats a violation as a failure. Mutation-tested by dropping `fonts.googleapis.com` from `style-src`: it fails on all four pages at both widths, naming the exact blocked stylesheet.

## One thing only production could have caught

After deploying, the live site logged three console errors per page load: Cloudflare injects its Web Analytics beacon at the edge, *after* the build, so the CSP knew nothing about it and blocked it every time.

Nothing visibly broke, but a CSP that reports violations on every load is one people learn to ignore, which is how the real violation gets missed later. Fixed by allowing `static.cloudflareinsights.com`. Worth noting the local suite could not have found this: the beacon does not exist in `dist/`, only in what the edge serves.

## Verified on the live domain

| Check | Result |
|---|---|
| HTTPS | working, certificate issued |
| `/`, `/docs/`, `/blog/`, `/releases/` | 200 |
| Unknown paths | 404 |
| CSP + `X-Frame-Options` | present on every response |
| Console errors | none |

## Setup already done

Pages project created, custom domain attached and validated, DNS pointed at Cloudflare, and both repository secrets set. Merging this makes future pushes to `site/` deploy automatically.
