### PR TITLE
Correct two overstated claims from the gosec fixes

### DIFF
--- a/cmd/consolidate/main.go
+++ b/cmd/consolidate/main.go
@@ -160,10 +160,16 @@ func main() {
 // cmd/server for why slog has no Fatal of its own.
 //
 // The offending value goes in attrs as a slog attribute rather than being
-// concatenated into msg. That keeps msg a constant, which matters for two
-// reasons: a log aggregator can group on it instead of seeing every bad value
-// as a distinct message, and an environment variable containing a newline
-// cannot forge a second log line by being spliced into the text.
+// concatenated into msg, so msg stays a constant. That is a legibility fix
+// rather than a security one: a log aggregator can group on a constant
+// message instead of treating every bad value as a distinct one.
+//
+// It is *not* what stops log forging - slog's JSON and text handlers both
+// escape newlines in a message, verified against the pre-fix binary, so a
+// value containing a newline never produced a second log line either way.
+// gosec flags the pattern (G706) because it cannot see the handler's
+// escaping. TestRejectedValueCannotForgeALogLine pins that behaviour, since
+// it belongs to the handler rather than to this code.
 func fatal(msg string, err error, attrs ...slog.Attr) {
 	slog.LogAttrs(context.Background(), slog.LevelError, msg,
 		append([]slog.Attr{slog.Any("error", err)}, attrs...)...)

--- a/cmd/consolidate/main_test.go
+++ b/cmd/consolidate/main_test.go
@@ -202,3 +202,52 @@ func TestUnreachableDatabaseExitsNonZero(t *testing.T) {
 		t.Errorf("the job exited 0 against an unreachable database: %s", out)
 	}
 }
+
+// TestRejectedValueCannotForgeALogLine pins the behaviour that makes echoing
+// an operator-supplied value into the log safe.
+//
+// The tuning variables are echoed back on rejection so an operator can see
+// what they typed. gosec flags that as log injection (G706), and the obvious
+// worry is a value containing a newline splicing a second, fabricated entry
+// into the stream - an audit trail that says maintenance completed when it
+// did not.
+//
+// slog's handlers escape newlines in both message and attributes, so this is
+// not actually possible. That is worth a test rather than a comment: it is a
+// property of the handler, not of this code, and switching to a handler that
+// wrote raw text would silently make the echo unsafe.
+func TestRejectedValueCannotForgeALogLine(t *testing.T) {
+	bin := consolidateBinary(t)
+
+	const forged = "FORGED-ENTRY-MARKER"
+	payload := "0.5\n{\"level\":\"INFO\",\"msg\":\"" + forged + "\",\"pruned\":0}"
+
+	for _, format := range []string{"json", "text"} {
+		t.Run(format, func(t *testing.T) {
+			out, code := runConsolidate(t,
+				bin,
+				"CONSOLIDATION_STALE_THRESHOLD="+payload,
+				"KORA_LOG_FORMAT="+format,
+			)
+			if code == 0 {
+				t.Fatal("the job accepted an unparseable threshold")
+			}
+
+			// The marker may appear escaped inside a field. What must not
+			// happen is a line that consists of the injected record, which is
+			// what a log reader would parse as a separate event.
+			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "{\"level\"") || strings.HasPrefix(trimmed, "level=") {
+					t.Errorf("a value forged its own log line: %q", trimmed)
+				}
+			}
+
+			// And the message itself stays constant, so an aggregator groups
+			// these rather than seeing one distinct message per bad value.
+			if !strings.Contains(out, "CONSOLIDATION_STALE_THRESHOLD is not a number") {
+				t.Errorf("expected the constant message, got: %s", out)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -201,9 +201,10 @@ func TestValidateRejectsOutOfRangeValues(t *testing.T) {
 		{
 			name: "embedding dimension that wraps uint32",
 			env:  map[string]string{"KORA_EMBEDDING_DIM": "4294967296"},
-			why: "2^32 converts to uint32(0) in the bag-of-words hash, so the " +
-				"server started cleanly and panicked with a divide-by-zero on " +
-				"the first memory stored",
+			why: "2^32 converts to uint32(0) in the bag-of-words hash. Postgres " +
+				"rejects the column width first, so the server never reached " +
+				"the panic, but it died with SQLSTATE 22003 from the database " +
+				"instead of a message naming the variable",
 		},
 		{
 			name: "absurd embedding dimension",

--- a/internal/embedding/bag_of_words.go
+++ b/internal/embedding/bag_of_words.go
@@ -35,13 +35,23 @@ type BagOfWordsEmbedder struct {
 
 // maxDim caps the vector dimension this embedder will accept.
 //
-// KORA_EMBEDDING_DIM is operator-supplied and was only checked for being
-// negative, so `KORA_EMBEDDING_DIM=4294967296` passed validation, started the
-// server cleanly, and took it down on the first memory stored.
+// Without it, a dim that is an exact multiple of 2^32 converts to uint32(0)
+// and the hashing below panics with a divide-by-zero. KORA_EMBEDDING_DIM is
+// operator-supplied and was validated only for being negative, so
+// NewBagOfWordsEmbedder(4294967296).Embed(...) panicked.
+//
+// In the server that panic was unreachable: cmd/server sizes the pgvector
+// column from Dimension() during InitSchema, before it serves anything, and
+// Postgres rejects a width of 4294967296 as out of range for int4. No
+// dimension pgvector will accept (1..16000) can wrap, since the smallest
+// wrapping value is already 2^32. The cap is still worth having - it turns a
+// confusing SQLSTATE 22003 from the database into a clear error naming the
+// variable, and it stops a future caller with no column in the way (a test, a
+// re-embedding tool) from finding the panic the hard way.
 //
 // 65536 is far above any real embedding model - the largest in common use is
-// 3072 - so the cap refuses nothing legitimate, and it keeps the dimension
-// comfortably inside uint32.
+// 3072, and pgvector itself stops at 16000 - so the cap refuses nothing
+// legitimate.
 const maxDim = 65536
 
 // NewBagOfWordsEmbedder creates an embedder with the given vector dimension.

--- a/internal/embedding/bag_of_words_test.go
+++ b/internal/embedding/bag_of_words_test.go
@@ -85,12 +85,19 @@ func cosine(a, b []float32) float64 {
 
 // TestEmbedSurvivesDimensionsThatOverflowUint32 guards a divide-by-zero panic.
 //
-// Embed hashes tokens into the vector with `fnvHash(token) % uint32(e.dim)`.
-// dim is an int, so a value that is an exact multiple of 2^32 converts to
-// uint32(0) and the modulo panics. That is reachable from configuration:
-// KORA_EMBEDDING_DIM is operator-supplied, and validation only rejected
-// negatives, so 4294967296 started the server cleanly and brought it down on
-// the first memory stored.
+// Embed hashes tokens into the vector with `fnvHash(token) % dim`, and dim was
+// an int converted to uint32 in the loop. A value that is an exact multiple of
+// 2^32 converts to uint32(0) and the modulo panics.
+//
+// Scope, stated honestly: this was not reachable through the running server.
+// cmd/server sizes the pgvector column from Dimension() during InitSchema,
+// before serving, and Postgres rejects a width of 4294967296 as out of range
+// for int4, so the process exits first. No dimension pgvector accepts
+// (1..16000) can wrap - the smallest wrapping value is 2^32 itself.
+//
+// The test is still worth keeping: this package's API is callable from
+// anywhere in the module, and a caller with no Postgres column in the way -
+// a test, a re-embedding tool, a benchmark - would hit the panic directly.
 //
 // The values below are the ones that actually wrap. 4294967296 is 2^32 and
 // 8589934592 is 2^33; both convert to zero. 4294967297 converts to 1, which


### PR DESCRIPTION
Re-ran the feedback loop over the **whole merged result** rather than just my diff, and two claims in #12 turned out stronger than the evidence supports. No code changes - this corrects the record where a future reader would find it, and adds the test that should have backed the second claim.

## 1. The embedding panic was not reachable through the server

**#12 said:** `KORA_EMBEDDING_DIM=4294967296` "started the server cleanly and took it down on the first memory stored."

**Actually:** I built the pre-fix binary and ran it against a real Postgres. `cmd/server` sizes the pgvector column from `Dimension()` in `InitSchema`, before serving:

```
level=ERROR msg="failed to init graph schema"
  error="create public.memory_embeddings table:
         ERROR: value \"4294967296\" is out of range for type integer (SQLSTATE 22003)"
exit 1
```

Same on a fresh database. And no wrapping value is reachable at all: the wrap needs `dim = 0 (mod 2^32)`, but pgvector accepts at most 16000. I probed every dimension in `1..16000` against the pre-fix code - **zero panics**.

The panic is real and reproducible through the package's own API, so the fix and its test stay. But it was a latent library defect, not a live remote-triggerable crash. The comments now say that.

**What the fix is actually worth:** a clear startup error naming `KORA_EMBEDDING_DIM` instead of a confusing SQLSTATE from the database, and a removed footgun for any future caller with no Postgres column in the way.

## 2. The log-injection fix is legibility, not security

**#12 said:** moving the value out of the message stopped "an environment variable containing a newline forging a second log line."

**Actually:** it never could. slog's JSON and text handlers both escape newlines - verified against the pre-fix binary in both formats. gosec flags the pattern because it cannot see the handler's escaping.

What the change does buy is a constant `msg` an aggregator can group on. Worth having, but not a security fix.

Since the escaping is a property of the handler rather than of this code, a future switch to something writing raw text would silently make the echo unsafe. So `TestRejectedValueCannotForgeALogLine` now pins it - asserting no injected record can occupy a line of its own, in either format.

**Mutation-tested:** replacing the slog call with a raw `Fprintln` fails the test, naming the forged line:

```
main_test.go:242: a value forged its own log line:
  "{\"level\":\"INFO\",\"msg\":\"FORGED-ENTRY-MARKER\",\"pruned\":0}"
```

## Still true from #12

The CLI flag wrap (`--top-k 3000000000` becomes `-1294967296`) was a genuine user-facing bug. gosec 19 to 0. Security Scan green on main.

## Verification over merged main

| Check | Result |
|---|---|
| build, vet, gofmt | clean |
| `go test -race ./...` | all packages pass |
| gosec, workflow's own args | 0 issues across 29 files |
| helm lint + template | clean, 18 manifests, only `KORA_*` |
| docker build, both images | ok |
| fix inside the shipped container | rejects the bad dim, exit 1 |
| live store + query vs real Postgres | 200, hybrid query scored 0.89 |
