### PR TITLE
Verify the docsify claims; stop the metrics table drifting

### DIFF
--- a/site/public/docs/config.js
+++ b/site/public/docs/config.js
@@ -2,8 +2,13 @@
 //
 // In a separate file rather than an inline <script>, which is what docsify's
 // quickstart shows: public/_headers sets a Content-Security-Policy with no
-// 'unsafe-inline' in script-src, so an inline config block would be dropped by
-// the browser and the docs would render as a blank page in production only.
+// 'unsafe-inline' in script-src, so an inline config block is dropped by the
+// browser and docsify never boots - leaving the pre-JavaScript fallback on
+// screen, in production only.
+//
+// Verified rather than assumed: inlining this file under the real CSP gives
+// "Executing inline script violates the following Content Security Policy
+// directive 'script-src 'self''", no .markdown-section, and zero sidebar links.
 
 window.$docsify = {
   // docsify defaults this to '#app'. The rest of the site renders into '#root',
@@ -30,9 +35,13 @@ window.$docsify = {
   // unmatched path under /docs/ back to this index.html. That rewrite is a
   // piece of hosting configuration with no local equivalent, so a broken one
   // fails only in production, and only on a hard refresh of a deep link -
-  // the exact case nobody clicks through before deploying. Hash routing has
-  // no such failure mode: the server only ever serves /docs/index.html, and
-  // the fragment never reaches it.
+  // the exact case nobody clicks through before deploying.
+  //
+  // Measured against a server that mirrors Cloudflare Pages (static files, no
+  // SPA rewrite): /docs/#/api cold-loads HTTP 200 and renders "API reference",
+  // while history mode's /docs/api returns HTTP 404. Hash routing has no such
+  // failure mode - the server only ever serves /docs/index.html, and the
+  // fragment never reaches it.
   routerMode: 'hash',
 
   loadSidebar: true,

--- a/site/public/docs/operations.md
+++ b/site/public/docs/operations.md
@@ -57,8 +57,10 @@ Prometheus metrics are on `/metrics`, on the HTTP port, requiring no API key. Na
 | `kora_memories_total` | counter | Memories created |
 | `kora_edges_total` | counter | Edges created |
 | `kora_requests_total` | counter | Requests, by outcome |
+| `kora_request_duration_seconds` | histogram | RPC latency, labelled by method - the D of RED, for every method rather than the two instrumented by hand |
 | `kora_query_duration_seconds` | histogram | Query latency |
 | `kora_store_duration_seconds` | histogram | Store latency |
+| `kora_query_results_count` | histogram | How many results each query returned, bucketed for the usual 0-20 |
 | `kora_active_sessions` | gauge | Sessions currently open |
 | `kora_pool_connections` | gauge | Connection pool state |
 | `kora_pool_acquire_wait_seconds_total` | counter | Time spent waiting for a connection |

--- a/site/scripts/check-docs.mjs
+++ b/site/scripts/check-docs.mjs
@@ -257,6 +257,38 @@ for (const page of pages) {
   }
 }
 
+// 10. The metrics table must match the metrics the engine actually exports.
+//
+// operations.md lists every kora_* metric by name. That list is the kind of
+// documentation that rots invisibly: a metric added in Go is simply absent
+// here, and a renamed one leaves a table entry pointing at something that no
+// longer exists - which an operator only discovers when their dashboard query
+// returns nothing. Two were already missing when this check was written.
+//
+// Compared against internal/metrics/metrics.go, which is the definition. The
+// check is skipped when that file is not reachable, so the site can still be
+// built from a standalone copy of site/.
+{
+  const source = join(root, '..', 'internal', 'metrics', 'metrics.go')
+  const page = join(docs, 'operations.md')
+
+  if (existsSync(source) && existsSync(page)) {
+    const declared = new Set(
+      [...readFileSync(source, 'utf8').matchAll(/Name:\s*"(kora_[a-z_]+)"/g)].map((m) => m[1]),
+    )
+    const documented = new Set(
+      [...readFileSync(page, 'utf8').matchAll(/`(kora_[a-z_]+)`/g)].map((m) => m[1]),
+    )
+
+    for (const name of declared) {
+      check(documented.has(name), `${name} is exported but missing from the docs metrics table`)
+    }
+    for (const name of documented) {
+      check(declared.has(name), `docs list ${name}, which the engine does not export`)
+    }
+  }
+}
+
 if (failures.length > 0) {
   console.error(`\ndocs check failed (${failures.length}):\n`)
   for (const f of failures) console.error(`  - ${f}`)

--- a/site/scripts/sync-docsify.mjs
+++ b/site/scripts/sync-docsify.mjs
@@ -2,11 +2,15 @@
 //
 // docsify's own quickstart loads the library from a CDN. This site cannot do
 // that: public/_headers sets `script-src 'self'`, so a jsdelivr <script> tag is
-// blocked by the browser before it executes, and the docs would render as a
-// blank page in production while looking perfect in any local test that skips
-// the headers. Relaxing the CSP to allow a third-party origin to execute
-// arbitrary script on the docs domain is the wrong trade for saving one copy
-// step, so the runtime is vendored instead and served from our own origin.
+// blocked by the browser before it executes, and the docs get stuck on their
+// pre-JavaScript fallback in production while looking perfect in any local test
+// that skips the headers. Verified: serving the shell with a jsdelivr script
+// under the real CSP gives "Loading the script ... violates the following
+// Content Security Policy directive", no .markdown-section, and only the
+// hand-written fallback on screen. Relaxing the CSP to allow a third-party
+// origin to execute arbitrary script on the docs domain is the wrong trade for
+// saving one copy step, so the runtime is vendored instead and served from our
+// own origin.
 //
 // Vendoring from node_modules rather than committing a blob keeps the upgrade
 // path honest: `pnpm up docsify` then a rebuild, with the version recorded in


### PR DESCRIPTION
Two claims in #12 turned out overstated once I tested them against the real system instead of reasoning about them. This audits the claims I wrote during the docsify work for the same defect, by actually reproducing each one.

## Three held

| Claim | Evidence |
|---|---|
| A CDN `<script>` is blocked by the CSP | Served the shell with a jsdelivr tag under the real CSP: `Loading the script ... violates the following Content Security Policy directive`, no `.markdown-section` |
| An inline config block is blocked | Inlined `config.js` under the same CSP: `Executing inline script violates ... 'script-src 'self''`, zero sidebar links |
| History mode needs a host rewrite | Against a server mirroring Cloudflare Pages: `/docs/#/api` cold-loads **200** and renders "API reference"; history mode's `/docs/api` returns **404** |

Each comment now carries the observation rather than the assertion.

## One was wrong, in the same way as before

Both comments said the docs would render as "a blank page". They don't. docsify never boots, so the hand-written pre-JavaScript fallback stays on screen - about 2,000 characters of readable text.

That's the fallback working as designed. Calling it blank would send someone debugging the wrong thing. Corrected in both places.

## The audit also found a real gap

The operations page listed **9 of the 11** metrics the engine exports. Missing: `kora_request_duration_seconds` and `kora_query_results_count`.

Added - and `check-docs.mjs` now compares the table against `internal/metrics/metrics.go` **in both directions**, so a metric added, renamed, or removed in Go fails the build instead of leaving an operator with a dashboard query that silently returns nothing.

Mutation-tested by renaming one entry:

```
- kora_query_results_count is exported but missing from the docs metrics table
- docs list kora_query_results_countt, which the engine does not export
```

## Checked and accurate

Ranking weights (0.55/0.25/0.10/0.10), the decay formula, consolidation defaults and phase order, the Postgres CPU and `shm` reasoning, and the note that the Python SDK wraps neither `extract` nor `profiles`.

## Verification

`pnpm check` green: typecheck, build, palette, build output, docs, browser at 1440/390, no-JS audit, WebKit + Firefox, waitlist.
