### PR TITLE
Finish the claims audit: one more was false

### DIFF
--- a/site/public/docs/config.js
+++ b/site/public/docs/config.js
@@ -23,8 +23,14 @@ window.$docsify = {
   repo: 'https://github.com/NarayanaSabari/Kora',
 
   // docsify fetches Markdown relative to this directory, so the route
-  // `#/quickstart` loads /docs/quickstart.md. Without it docsify would look at
-  // the site root and every page would 404.
+  // `#/quickstart` loads /docs/quickstart.md.
+  //
+  // Kept explicit rather than because it is required: docsify infers the same
+  // base from the page URL, and removing this line changes nothing - measured,
+  // the identical set of .md requests goes out either way. It earns its place
+  // by pinning the assumption. The docs are only correct while they are served
+  // from /docs/, and a future move would otherwise depend on that inference
+  // continuing to hold.
   basePath: '/docs/',
   relativePath: false,
 

--- a/site/scripts/check-docs.mjs
+++ b/site/scripts/check-docs.mjs
@@ -161,9 +161,12 @@ check(
 
 // 6. Sidebar entries must resolve to files that exist.
 //
-// This is the failure this script exists for. docsify silently renders its
-// "not found" page for a missing document: the build passes, the sidebar looks
-// complete, and the gap only appears when a reader clicks the link.
+// This is the failure this script exists for. Measured against a build with a
+// deliberately broken sidebar entry: the link renders in the nav, clicking it
+// shows docsify's "Not found" body, and the only signal is a 404 in the
+// browser console. The build passes, the sidebar looks complete, and nothing
+// in CI notices - so the gap reaches a reader who clicks the link, or a
+// crawler, before it reaches anyone who could fix it.
 const pages = readdirSync(docs).filter((f) => f.endsWith('.md'))
 check(pages.length > 0, 'dist/docs/ contains no Markdown at all')
 


### PR DESCRIPTION
The previous pass tested four claims I picked by hand. That is not an audit. This enumerates **every** falsifiable "X would fail" assertion added across the docsify work and tests the ones still only reasoned about.

## Three more hold

| Claim | What was measured |
|---|---|
| The `/docs/` CSP relaxation is required | Serving the docs under the strict global policy produces **2** `Applying inline style violates ...` violations - the search plugin and progress bar, as described |
| Only `style-src` was relaxed | Production sends exactly **one** CSP header per path. On `/docs/`: `script-src 'self'`, with `object-src`, `base-uri`, `frame-ancestors`, `form-action` unchanged. The `! Content-Security-Policy` detach works - one header, not two merged |
| Stripping `sourceMappingURL` avoids a 404 | Upstream ships `.map` files that are deliberately not vendored, so an unstripped reference would point at nothing |

## One was false

The `basePath` comment said that without it "docsify would look at the site root and every page would 404."

Removing the line changes **nothing**. docsify infers the same base from the page URL - the identical set of `.md` requests goes out either way, on the index and on a deep route:

```
basePath present:  /docs/README.md, /docs/_sidebar.md, /docs/quickstart.md, ...
basePath REMOVED:  /docs/README.md, /docs/_sidebar.md, /docs/quickstart.md, ...
```

The line is still worth keeping - it pins an assumption that a future move off `/docs/` would otherwise silently depend on - but the comment now says that, instead of inventing a failure.

## One was imprecise

`check-docs.mjs` said docsify renders its not-found page "silently" for a missing sidebar entry. It logs a 404 to the browser console. The point stands (nothing in the build or CI notices, so the gap reaches a reader first) and the comment now describes what was observed:

```
ghost link present in sidebar: true
after clicking: h1="Not found"
JS errors: 4x "Failed to load resource: the server responded with a status"
```

## The pattern

Three wrong or overstated claims across this work, all the same shape: asserting a failure mode I had reasoned about but never triggered. The fix each time was to run it.

`pnpm check` green.
