### PR TITLE
chore(deps): bump the Go builder to 1.27 and the runtime to alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/kora-server ./cmd/server
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/kora-consolidate ./cmd/consolidate
 
 # Stage 2: Runtime (alpine for healthcheck support)
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates wget
 RUN adduser -D -u 1000 kora


### PR DESCRIPTION
Applies Dependabot #17 and #18 together, since they edit the same Dockerfile and are only meaningful as a pair.

Verified by building and running rather than by reading the diff:

- The image builds, starts against a live Postgres+AGE, initializes the graph schema, and completes a store and query round trip over REST.
- Trivy reports zero CRITICAL or HIGH findings on the new base -- and also zero on alpine 3.20, so this is not a CVE fix. It is staying current so the next advisory lands on a base one step behind rather than four.

`go.mod` deliberately stays at 1.26.1 and CI still tests on 1.26. The builder shipping a newer toolchain than the tests run against is supported by Go; raising the language version is a separate decision about the minimum Go a contributor needs.

Closes #17. Closes #18.