### PR TITLE
chore(deps): bump the web image to Node 26, and stop using corepack

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,16 @@
 # Stage 1: Build
-FROM node:22-alpine AS builder
-RUN corepack enable && corepack prepare pnpm@latest --activate
+FROM node:26-alpine AS builder
+
+# pnpm is installed with npm rather than through corepack. Node 26 no longer
+# ships corepack -- `corepack enable` fails with "not found" -- so the previous
+# line broke the build outright on this base.
+#
+# The version is pinned rather than @latest, which is what corepack was asked
+# for. A build that resolves its own package manager at build time is not
+# reproducible: the same commit could build with a different pnpm next week and
+# resolve the lockfile differently. This is the major matching the local
+# toolchain and the lockfileVersion 9.0 in pnpm-lock.yaml.
+RUN npm install -g pnpm@11.21.0
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Applies Dependabot #16, which could not merge as opened: its Build check failed, and the cause is a real incompatibility rather than a flake.

**Node 26 no longer ships corepack.** `corepack enable` exits 127 with "not found", so the first `RUN` in `web/Dockerfile` failed outright. Confirmed directly against the base image: `node:26-alpine` reports v26.7.0 and has no corepack on PATH.

pnpm is now installed with npm, and **pinned to 11.21.0** rather than the `@latest` corepack was asked for. That part was already fragile independent of the bump: a build that resolves its own package manager at build time is not reproducible, and the same commit could resolve a different pnpm next week and install the lockfile differently.

Verified by running the image, not just building it. The first attempt appeared to fail and did not -- nginx exits when it cannot resolve the `api` upstream, which does not exist outside the compose network. On that network the image serves HTTP 200 with the Kora UI title, proxies `/v1/health` through to the API, and still runs as uid 101, which is what keeps the pod inside the Pod Security restricted profile.

Closes #16.