### PR TITLE
chore(ci): bump the four release-only action majors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
@@ -85,7 +85,7 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -95,7 +95,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} --username ${{ github.actor }} --password-stdin


### PR DESCRIPTION
Applies Dependabot #27, #28, #30, and #31 together. All four appear only in `release.yaml`, all four are the same underlying change -- Node 20 to Node 24 runtime, requiring Actions Runner 2.327.1, which GitHub-hosted runners satisfy -- and none has a breaking input change.

They could not be verified before now: nothing in CI runs `release.yaml`, and the only way to exercise it was to cut a tag. The dry-run dispatch added in 3eacfb9 fixes that, and this branch was validated through it.

**Dry run on this branch: all 11 build jobs succeeded, GitHub Release skipped, nothing published.** That covers metadata-action generating tags, login-action authenticating to GHCR, build-push-action building both platforms, and setup-helm packaging the chart.

Closes #27. Closes #28. Closes #30. Closes #31.