### PR TITLE
chore(ci): bump the remaining action majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -73,9 +73,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -92,7 +92,7 @@ jobs:
           go tool cover -func=coverage.out | tail -1
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -105,9 +105,9 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -148,9 +148,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -257,7 +257,7 @@ jobs:
               echo "::error::consolidation.pruneAgeDays does not reach the CronJob"; exit 1; }
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries
           path: bin/
@@ -269,9 +269,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,9 +38,9 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -68,7 +68,7 @@ jobs:
             dockerfile: web/Dockerfile
             context: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
@@ -128,9 +128,9 @@ jobs:
             goarch: amd64
             ext: .exe
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -145,7 +145,7 @@ jobs:
             -o kora-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/cli
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kora-${{ matrix.goos }}-${{ matrix.goarch }}
           path: kora-*
@@ -159,7 +159,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Helm
         uses: azure/setup-helm@v5
@@ -184,9 +184,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -197,7 +197,7 @@ jobs:
           python -m build
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-sdk
           path: sdk/python/dist/
@@ -220,19 +220,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: kora-*
           path: release-assets/
           merge-multiple: true
 
       - name: Download Python SDK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-sdk
           path: release-assets/
@@ -256,7 +256,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: release-assets/*

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -16,9 +16,9 @@ jobs:
     name: Go Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
 
@@ -56,7 +56,7 @@ jobs:
     name: Container Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build images
         run: |
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -38,9 +38,9 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -102,7 +102,7 @@ jobs:
       # so what ships is byte-for-byte what was checked.
       - name: Upload verified build
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: site-dist
           path: site/dist
@@ -118,10 +118,10 @@ jobs:
       name: production
       url: https://kora.sabarinarayana.com
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download verified build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: site-dist
           path: site/dist
@@ -133,7 +133,7 @@ jobs:
       # certificate, with the site down in between. The project serves
       # kora.sabarinarayana.com; only the internal identifier is historical.
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Applies Dependabot #29, #35, #36, #37, #38, #39, #40, #41, plus `setup-go` v5→v7 which had not surfaced a PR yet.

Batched rather than merged one at a time because they edit the same four workflow files, and because **upload-artifact and download-artifact must move together**. The default Dependabot limit of 5 had surfaced upload-artifact without download-artifact; merging the visible one alone would have left v7 writing artifacts and v4 reading them.

`download-artifact` v8 is the only one with real breaking changes, and both are safe here:

- It no longer unzips unconditionally. That matters only for uploads using the new `archive: false` — this repo has none, so every artifact is still a zip.
- A digest mismatch now fails the run instead of logging a warning. That is a security improvement worth taking.

The rest are the Node 20 → Node 24 runtime migration CI has been warning about on every run, requiring Actions Runner 2.327.1, which GitHub-hosted runners satisfy.

Validation: CI exercises checkout, setup-go, setup-node, upload-artifact and dependency-review; the site workflow exercises download-artifact and wrangler-action; and a release dry run covers the rest.

Closes #29. Closes #35. Closes #36. Closes #37. Closes #38. Closes #39. Closes #40. Closes #41.