### PR TITLE
feat: add an MCP server for Claude Code, Cursor, and Windsurf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,18 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
+  # The MCP server is a second Python package. It originally used poetry with a
+  # committed lock file, which the pip ecosystem does not read, so it was
+  # covered by nothing; it builds with setuptools now, like sdk/python.
+  - package-ecosystem: pip
+    directory: /mcp-server
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+
   # Both images are scanned by Trivy in security.yaml, so a base-image CVE is
   # already visible; this is what makes it fixable without hand-editing.
   - package-ecosystem: docker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,6 +377,19 @@ jobs:
           KORA_API_KEY: ${{ env.E2E_API_KEY }}
         run: python3 sdk/python/tests/test_e2e.py
 
+      # The MCP server is the same shape of risk as the SDK above, and shipped
+      # with no coverage at all: its own route table, its own field parsing,
+      # and a mapping from human words ("semantic") to wire enum values that
+      # nothing checked. It is what an editor talks to, so a break here is
+      # invisible until an agent silently stops remembering things.
+      - name: Run MCP server E2E tests
+        env:
+          KORA_HTTP_URL: http://localhost:8080
+          KORA_API_KEY: ${{ env.E2E_API_KEY }}
+        run: |
+          pip install --quiet ./mcp-server
+          python3 mcp-server/tests/test_e2e.py
+
       - name: Run E2E tests
         env:
           KORA_E2E_HTTP: http://localhost:8080

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -262,11 +262,20 @@ jobs:
           name: binaries
           path: bin/
 
-  # ── E2E Tests (main only) ────────────────────────────
+  # ── E2E Tests ─────────────────────────────────────────
+  #
+  # Runs on pull requests as well as main. It was main-only, which had two
+  # consequences worth stating: a change could only fail here after it had
+  # already merged, and "E2E Tests" as a required status check was satisfied by
+  # being skipped -- protection that looked present and was not.
+  #
+  # It is the most expensive job at roughly eight minutes, because it stands up
+  # a kind cluster, deploys the chart, and drives the CLI, the Python SDK, and
+  # the MCP server against a live engine. That is also why it is worth waiting
+  # for: it is the only job that would notice the deployment path breaking.
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     needs: [build]
     steps:
       - uses: actions/checkout@v7

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,119 @@
+# Kora MCP Server
+
+MCP server that gives any AI agent persistent memory via the Kora engine.
+
+Works with **Claude Code, Cursor, Windsurf, Cline**, and any MCP-compatible client.
+
+## Setup
+
+### Prerequisites
+
+- Kora engine running (via Docker Compose or K8s)
+- Python 3.10+
+
+### Install
+
+```bash
+cd mcp-server
+pip install -e .
+```
+
+### Configure Claude Code
+
+Add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "kora": {
+      "command": "kora-mcp",
+      "env": {
+        "KORA_HTTP_URL": "http://localhost:8080",
+        "KORA_API_KEY": "<your key: go run ./cmd/cli keys generate>",
+        "KORA_PROJECT": "my-project"
+      }
+    }
+  }
+}
+```
+
+### Configure Cursor
+
+Add to Cursor settings (MCP section):
+
+```json
+{
+  "mcpServers": {
+    "kora": {
+      "command": "kora-mcp",
+      "env": {
+        "KORA_HTTP_URL": "http://localhost:8080",
+        "KORA_API_KEY": "<your key: go run ./cmd/cli keys generate>"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `memory_store` | Store a fact, event, or procedure |
+| `memory_query` | Search memories by natural language |
+| `memory_extract` | Auto-extract memories from a conversation |
+| `memory_profile` | Get aggregated user/project profile |
+| `memory_connect` | Create relationship between memories |
+| `memory_delete` | Delete a memory |
+| `memory_graph` | View subgraph around a memory |
+
+## Available Resources
+
+| Resource | Description |
+|----------|-------------|
+| `memory://health` | Engine health and statistics |
+| `memory://profile/{project_id}` | User/project profile |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KORA_HTTP_URL` | `http://localhost:8080` | Kora REST API URL |
+| `KORA_API_KEY` | (empty) | API key for authentication |
+| `KORA_PROJECT` | `default` | Default project ID |
+
+## Run Standalone
+
+```bash
+# stdio (for Claude Code, Cursor)
+kora-mcp
+
+# HTTP transport (for remote clients)
+kora-mcp --transport http --port 8000
+```
+
+## Development
+
+```bash
+# Install with dev deps
+pip install -e ".[dev]"
+
+# Test the server interactively
+fastmcp dev kora_mcp/server.py
+```
+
+### Tests
+
+The suite runs against a real engine rather than mocks, because what breaks
+here is the boundary: a route that moved, a response field that was renamed,
+or the memory-type mapping drifting from the API's enum. None of that is
+visible to a mocked test.
+
+```bash
+# With an engine reachable (docker compose up, or make deploy)
+KORA_HTTP_URL=http://localhost:8080 \
+KORA_API_KEY="$(go run ../cmd/cli keys generate)" \
+  python3 tests/test_e2e.py
+```
+
+CI runs this against the kind cluster on every push.

--- a/mcp-server/kora_mcp/__init__.py
+++ b/mcp-server/kora_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Kora MCP Server — memory engine for any MCP-compatible AI agent."""
+
+__version__ = "0.1.0"

--- a/mcp-server/kora_mcp/client.py
+++ b/mcp-server/kora_mcp/client.py
@@ -1,0 +1,174 @@
+"""HTTP client for the Kora REST API.
+
+Provides a thin async wrapper around the Kora /v1/* endpoints
+using httpx. All methods return parsed JSON dicts.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any
+
+import httpx
+
+# Variables this package read before the project was renamed from Context0 to
+# Kora. The engine refuses to start when it sees one, and the CLI warns; this
+# is the same guard for the same reason.
+#
+# Every setting here has a fallback, so a stale variable is silently wrong
+# rather than an error: KORA_HTTP_URL left unset sends requests to localhost
+# instead of the configured engine, and KORA_API_KEY left unset sends no key at
+# all, which surfaces as 401s the caller has to work backwards from.
+#
+# This warns rather than raising, matching the CLI. An MCP server is launched
+# by an editor -- Claude Code, Cursor, Windsurf -- and a hard failure there
+# shows up as a tool that silently does not appear, which is harder to diagnose
+# than a warning in the server's stderr.
+_RENAMED_ENV = {
+    "CONTEXT0_URL": "KORA_HTTP_URL",
+    "CONTEXT0_API_KEY": "KORA_API_KEY",
+    "CONTEXT0_PROJECT": "KORA_PROJECT",
+}
+
+
+def warn_renamed_env() -> list[str]:
+    """Warn about pre-rename variables. Returns the names found, for tests."""
+    found = []
+    for old, new in _RENAMED_ENV.items():
+        if os.getenv(old):
+            found.append(old)
+            warnings.warn(
+                f"{old} is set but no longer read: the project was renamed to "
+                f"Kora. Use {new} instead.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+    return found
+
+
+class KoraClient:
+    """Async HTTP client for the Kora REST API."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        warn_renamed_env()
+        self.base_url = (base_url or os.getenv("KORA_HTTP_URL", "http://localhost:8080")).rstrip("/")
+        self.api_key = api_key or os.getenv("KORA_API_KEY", "")
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=self._headers(),
+            timeout=30.0,
+        )
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["X-API-Key"] = self.api_key
+        return h
+
+    async def health(self) -> dict[str, Any]:
+        """GET /v1/health"""
+        r = await self._client.get("/v1/health")
+        r.raise_for_status()
+        return r.json()
+
+    async def store(
+        self,
+        content: str,
+        project_id: str,
+        memory_type: int = 2,
+        tags: list[str] | None = None,
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        """POST /v1/memories — store a single memory."""
+        r = await self._client.post("/v1/memories", json={
+            "content": content,
+            "type": memory_type,
+            "project_id": project_id,
+            "tags": tags or [],
+            "session_id": session_id,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    async def query(
+        self,
+        query: str,
+        project_id: str,
+        top_k: int = 5,
+    ) -> dict[str, Any]:
+        """GET /v1/memories/query — search memories."""
+        r = await self._client.get("/v1/memories/query", params={
+            "query": query,
+            "project_id": project_id,
+            "top_k": top_k,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    async def extract(
+        self,
+        conversation: str,
+        project_id: str,
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        """POST /v1/memories/extract — auto-extract memories from conversation."""
+        r = await self._client.post("/v1/memories/extract", json={
+            "conversation": conversation,
+            "project_id": project_id,
+            "session_id": session_id,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    async def get_profile(
+        self,
+        project_id: str,
+        query: str = "",
+    ) -> dict[str, Any]:
+        """GET /v1/profiles/{project_id} — get user/project profile."""
+        params: dict[str, Any] = {}
+        if query:
+            params["query"] = query
+        r = await self._client.get(f"/v1/profiles/{project_id}", params=params)
+        r.raise_for_status()
+        return r.json()
+
+    async def connect(
+        self,
+        from_id: str,
+        to_id: str,
+        relationship: int = 1,
+        weight: float = 1.0,
+    ) -> dict[str, Any]:
+        """POST /v1/memories/connect — create edge between memories."""
+        r = await self._client.post("/v1/memories/connect", json={
+            "from_id": from_id,
+            "to_id": to_id,
+            "relationship": relationship,
+            "weight": weight,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    async def delete(self, memory_id: str) -> None:
+        """DELETE /v1/memories/{id} — delete a memory."""
+        r = await self._client.delete(f"/v1/memories/{memory_id}")
+        r.raise_for_status()
+
+    async def get_graph(
+        self,
+        center_id: str,
+        depth: int = 2,
+    ) -> dict[str, Any]:
+        """GET /v1/memories/{id}/graph — get subgraph."""
+        r = await self._client.get(f"/v1/memories/{center_id}/graph", params={"depth": depth})
+        r.raise_for_status()
+        return r.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/mcp-server/kora_mcp/server.py
+++ b/mcp-server/kora_mcp/server.py
@@ -1,0 +1,303 @@
+"""Kora MCP Server — gives any MCP-compatible AI agent persistent memory.
+
+Works with Claude Code, Cursor, Windsurf, Cline, and any MCP client.
+
+Tools:
+  - memory_store: Store a memory (fact, event, or procedure)
+  - memory_query: Search memories by natural language
+  - memory_extract: Auto-extract memories from a conversation
+  - memory_profile: Get aggregated user/project profile
+  - memory_connect: Create relationship between two memories
+  - memory_delete: Delete a memory
+  - memory_graph: Get subgraph around a memory
+
+Resources:
+  - memory://health: Engine health status
+  - memory://profile/{project_id}: User/project profile
+
+Environment:
+  KORA_HTTP_URL  Kora API base URL (default: http://localhost:8080)
+  KORA_API_KEY   API key for authentication
+  KORA_PROJECT   Default project ID (default: "default")
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Annotated
+
+from fastmcp import FastMCP, Context
+from pydantic import Field
+
+from kora_mcp.client import KoraClient
+
+# ── Server setup ────────────────────────────────────────────────────────
+
+mcp = FastMCP(
+    "Kora Memory",
+    instructions=(
+        "Kora provides persistent memory for AI agents. "
+        "Use memory_store to save important facts, decisions, and preferences. "
+        "Use memory_query to recall relevant context before answering questions. "
+        "Use memory_extract to process raw conversations into structured memories. "
+        "Use memory_profile to get a complete overview of what you know about a user or project."
+    ),
+)
+
+# Lazy-initialized client (created on first tool call).
+_client: KoraClient | None = None
+
+DEFAULT_PROJECT = os.getenv("KORA_PROJECT", "default")
+
+# Memory type mapping for human-readable input.
+MEMORY_TYPES = {"semantic": 2, "episodic": 1, "procedural": 3, "fact": 2, "event": 1, "howto": 3}
+REL_TYPES = {"relates_to": 1, "supersedes": 2, "caused_by": 3}
+
+
+def _get_client() -> KoraClient:
+    """Get or create the Kora API client."""
+    global _client
+    if _client is None:
+        _client = KoraClient()
+    return _client
+
+
+# ── Tools ───────────────────────────────────────────────────────────────
+
+@mcp.tool(
+    description="Store a new memory in the Kora knowledge graph. "
+    "Use this to save important facts, decisions, preferences, events, or procedures "
+    "that should be remembered across sessions.",
+    tags={"memory", "store"},
+)
+async def memory_store(
+    content: Annotated[str, Field(description="The memory content to store (a fact, event, or procedure)")],
+    memory_type: Annotated[str, Field(description="Type of memory: 'fact' (semantic), 'event' (episodic), or 'howto' (procedural)")] = "fact",
+    tags: Annotated[list[str], Field(description="Tags for categorization and retrieval")] = [],
+    project_id: Annotated[str, Field(description="Project to scope this memory to")] = "",
+) -> str:
+    """Store a memory in the knowledge graph."""
+    client = _get_client()
+    pid = project_id or DEFAULT_PROJECT
+    mt = MEMORY_TYPES.get(memory_type.lower(), 2)
+
+    result = await client.store(content=content, project_id=pid, memory_type=mt, tags=tags)
+    mem = result.get("memory", {})
+    return f"Stored memory {mem.get('id', 'unknown')[:8]}... [{memory_type}] tags={tags}"
+
+
+@mcp.tool(
+    description="Search memories by natural language query. "
+    "Use this to recall relevant context before answering questions or making decisions. "
+    "Returns ranked results with scores.",
+    tags={"memory", "query"},
+)
+async def memory_query(
+    query: Annotated[str, Field(description="Natural language search query")],
+    top_k: Annotated[int, Field(description="Maximum number of results to return", ge=1, le=20)] = 5,
+    project_id: Annotated[str, Field(description="Project to search within")] = "",
+) -> str:
+    """Search memories by natural language query."""
+    client = _get_client()
+    pid = project_id or DEFAULT_PROJECT
+
+    result = await client.query(query=query, project_id=pid, top_k=top_k)
+    results = result.get("results", [])
+
+    if not results:
+        return "No memories found for this query."
+
+    lines = [f"Found {len(results)} memories:\n"]
+    for i, r in enumerate(results, 1):
+        mem = r.get("memory", {})
+        score = r.get("score", 0)
+        mtype = mem.get("type", "").replace("MEMORY_TYPE_", "").lower()
+        tags = mem.get("tags", [])
+        content = mem.get("content", "")
+        lines.append(f"{i}. [{mtype}] (score: {score:.2f}) {content}")
+        if tags:
+            lines.append(f"   tags: {', '.join(tags)}")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    description="Auto-extract structured memories from a raw conversation. "
+    "Feed in a multi-turn conversation and the engine automatically identifies "
+    "facts, preferences, events, and procedures — creating memory nodes and "
+    "relationship edges in the knowledge graph.",
+    tags={"memory", "extract"},
+)
+async def memory_extract(
+    conversation: Annotated[str, Field(description="Raw conversation text (multi-turn, newline-separated)")],
+    project_id: Annotated[str, Field(description="Project to scope extracted memories to")] = "",
+) -> str:
+    """Auto-extract memories from a conversation."""
+    client = _get_client()
+    pid = project_id or DEFAULT_PROJECT
+
+    result = await client.extract(conversation=conversation, project_id=pid)
+    memories = result.get("memories", [])
+    rels = result.get("relationshipsCreated", 0)
+
+    if not memories:
+        return "No memories could be extracted from this conversation."
+
+    lines = [f"Extracted {len(memories)} memories ({rels} relationships created):\n"]
+    for mem in memories:
+        mtype = mem.get("type", "").replace("MEMORY_TYPE_", "").lower()
+        content = mem.get("content", "")
+        tags = mem.get("tags", [])
+        lines.append(f"- [{mtype}] {content}")
+        if tags:
+            lines.append(f"  tags: {', '.join(tags)}")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    description="Get an aggregated profile for a user or project, combining stable facts "
+    "(preferences, expertise, known information) with recent context (events from the "
+    "last 7 days). Use this at the start of a conversation to understand who you're "
+    "talking to.",
+    tags={"memory", "profile"},
+)
+async def memory_profile(
+    project_id: Annotated[str, Field(description="Project/user to get profile for")] = "",
+    query: Annotated[str, Field(description="Optional query to filter profile relevance")] = "",
+) -> str:
+    """Get aggregated user/project profile."""
+    client = _get_client()
+    pid = project_id or DEFAULT_PROJECT
+
+    result = await client.get_profile(project_id=pid, query=query)
+
+    static = result.get("staticProfile", [])
+    dynamic = result.get("dynamicProfile", [])
+    total = result.get("totalMemories", 0)
+
+    lines = [f"Profile for '{pid}' ({total} total memories):\n"]
+
+    if static:
+        lines.append("== Known Facts & Preferences ==")
+        for fact in static:
+            mtype = fact.get("type", "").replace("MEMORY_TYPE_", "").lower()
+            lines.append(f"- [{mtype}] {fact.get('content', '')}")
+    else:
+        lines.append("== No stable facts recorded yet ==")
+
+    lines.append("")
+
+    if dynamic:
+        lines.append("== Recent Context (last 7 days) ==")
+        for fact in dynamic:
+            lines.append(f"- {fact.get('content', '')}")
+    else:
+        lines.append("== No recent events ==")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    description="Create a relationship (edge) between two existing memories. "
+    "Use 'relates_to' for general associations, 'supersedes' when a newer fact "
+    "replaces an older one, or 'caused_by' for causal relationships.",
+    tags={"memory", "connect"},
+)
+async def memory_connect(
+    from_id: Annotated[str, Field(description="Source memory ID")],
+    to_id: Annotated[str, Field(description="Target memory ID")],
+    relationship: Annotated[str, Field(description="Type: 'relates_to', 'supersedes', or 'caused_by'")] = "relates_to",
+    weight: Annotated[float, Field(description="Strength of relationship (0-1)", ge=0, le=1)] = 1.0,
+) -> str:
+    """Create a relationship between two memories."""
+    client = _get_client()
+    rel = REL_TYPES.get(relationship.lower(), 1)
+    result = await client.connect(from_id=from_id, to_id=to_id, relationship=rel, weight=weight)
+    edge = result.get("edge", {})
+    return f"Created edge {edge.get('id', 'unknown')[:8]}... ({relationship}, weight={weight})"
+
+
+@mcp.tool(
+    description="Delete a memory from the knowledge graph.",
+    tags={"memory", "delete"},
+    annotations={"destructiveHint": True},
+)
+async def memory_delete(
+    memory_id: Annotated[str, Field(description="ID of the memory to delete")],
+) -> str:
+    """Delete a memory and its edges."""
+    client = _get_client()
+    await client.delete(memory_id)
+    return f"Deleted memory {memory_id[:8]}..."
+
+
+@mcp.tool(
+    description="Get the subgraph (neighboring memories and edges) around a specific memory. "
+    "Useful for understanding how a memory relates to other knowledge.",
+    tags={"memory", "graph"},
+)
+async def memory_graph(
+    memory_id: Annotated[str, Field(description="Center memory ID to explore around")],
+    depth: Annotated[int, Field(description="How many hops to traverse", ge=1, le=5)] = 2,
+) -> str:
+    """Get subgraph around a memory."""
+    client = _get_client()
+    result = await client.get_graph(center_id=memory_id, depth=depth)
+
+    nodes = result.get("nodes", [])
+    edges = result.get("edges", [])
+
+    lines = [f"Subgraph around {memory_id[:8]}... ({len(nodes)} nodes, {len(edges)} edges):\n"]
+
+    if nodes:
+        lines.append("Nodes:")
+        for n in nodes:
+            mtype = n.get("type", "").replace("MEMORY_TYPE_", "").lower()
+            lines.append(f"  [{mtype}] {n.get('id', '')[:8]}... {n.get('content', '')[:60]}")
+
+    if edges:
+        lines.append("\nEdges:")
+        for e in edges:
+            rel = e.get("relationship", "").replace("RELATIONSHIP_TYPE_", "").lower()
+            lines.append(f"  {e.get('fromId', '')[:8]}... --{rel}--> {e.get('toId', '')[:8]}...")
+
+    if not nodes and not edges:
+        lines.append("No neighboring memories found.")
+
+    return "\n".join(lines)
+
+
+# ── Resources ───────────────────────────────────────────────────────────
+
+@mcp.resource("memory://health", description="Kora engine health status and statistics")
+async def health_resource() -> str:
+    """Get engine health status."""
+    client = _get_client()
+    data = await client.health()
+    return (
+        f"Status: {data.get('status', 'unknown')}\n"
+        f"Version: {data.get('version', 'unknown')}\n"
+        f"Nodes: {data.get('nodeCount', 0)}\n"
+        f"Edges: {data.get('edgeCount', 0)}"
+    )
+
+
+@mcp.resource(
+    "memory://profile/{project_id}",
+    description="User/project profile with known facts and recent context",
+)
+async def profile_resource(project_id: str) -> str:
+    """Get profile as a resource."""
+    return await memory_profile(project_id=project_id)
+
+
+# ── Entry point ─────────────────────────────────────────────────────────
+
+def main():
+    """Run the Kora MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=84.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kora-mcp"
+version = "0.1.0"
+description = "MCP server for Kora — memory engine for AI agents"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.10"
+dependencies = [
+    "fastmcp>=3.2.0,<4.0.0",
+    "httpx>=0.28.1,<0.29.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
+]
+
+[project.scripts]
+kora-mcp = "kora_mcp.server:main"
+
+# setuptools rather than poetry-core, matching sdk/python. The two Python
+# packages in this repo used different build backends and different dependency
+# syntaxes, and this one shipped a 1,980-line poetry.lock that nothing updated:
+# Dependabot's pip ecosystem reads pyproject.toml, so the lock was covered by
+# neither it nor CI. One backend across both means one thing to keep current.
+[tool.setuptools.packages.find]
+include = ["kora_mcp*"]

--- a/mcp-server/tests/test_e2e.py
+++ b/mcp-server/tests/test_e2e.py
@@ -1,0 +1,244 @@
+"""End-to-end tests for the MCP server, against a running Kora.
+
+This package shipped with no tests at all: 440 lines of client and server
+code, a hand-maintained route table, and a memory-type mapping that turns
+human words into wire enum values. Nothing in CI would have noticed any of it
+breaking. sdk/python has 28 tests against a live engine; this is the same idea
+for the same reason, and deliberately mirrors that file's structure so the two
+read alike.
+
+What this covers that a unit test would not: every route the client calls
+actually exists on the engine, the field renaming on the way in still matches
+what the server returns, and the memory-type words the MCP tools accept still
+map to the enum values the API expects. All three are the kind of thing that
+breaks silently when the API moves.
+
+Run against a reachable deployment:
+
+    KORA_HTTP_URL=http://localhost:8080 KORA_API_KEY=ctx0_... \\
+        python3 mcp-server/tests/test_e2e.py
+"""
+
+import asyncio
+import os
+import sys
+import uuid
+import warnings
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from kora_mcp.client import KoraClient, warn_renamed_env  # noqa: E402
+
+URL = os.environ.get("KORA_HTTP_URL", "http://localhost:8080")
+KEY = os.environ.get("KORA_API_KEY", "")
+
+PASSED = 0
+FAILED = 0
+FAILURES = []
+
+
+def check(name, condition, detail=""):
+    global PASSED, FAILED
+    if condition:
+        print(f"  PASS  {name}")
+        PASSED += 1
+    else:
+        print(f"  FAIL  {name}")
+        if detail:
+            print(f"        {detail}")
+        FAILED += 1
+        FAILURES.append(name)
+
+
+def section(title):
+    print(f"\n{title}")
+
+
+async def attempt(name, coro):
+    """Await a client call, reporting an exception as a failure not a crash.
+
+    A removed route raises out of raise_for_status, and an unhandled traceback
+    loses every check after it -- so one defect would hide the rest.
+    """
+    try:
+        return await coro
+    except Exception as e:  # noqa: BLE001
+        check(name, False, f"{type(e).__name__}: {e}")
+        return None
+
+
+async def run():
+    project = f"mcp-test-{uuid.uuid4().hex[:8]}"
+    c = KoraClient(base_url=URL, api_key=KEY)
+    stored_id = None
+
+    section("1. Health")
+    h = await attempt("health() completes", c.health())
+    if h is None:
+        print("\ncannot reach the service; aborting", file=sys.stderr)
+        await c.close()
+        return 1
+    check("health() reports a status", h.get("status") == "ok", f"got {h.get('status')!r}")
+    # nodeCount is a string in the JSON gateway's output, not a number. The
+    # MCP resource formats it, so a type change here would surface as a
+    # confusing string in an agent's context rather than an error.
+    check("health() returns graph counts", "nodeCount" in h, f"keys: {sorted(h)}")
+
+    section("2. Store")
+    s = await attempt(
+        "store() completes",
+        c.store(content="MCP end-to-end probe", project_id=project, memory_type=2),
+    )
+    if s is not None:
+        mem = s.get("memory", {})
+        stored_id = mem.get("id")
+        check("store() returns an id", bool(stored_id), f"got {mem!r}")
+        check(
+            "store() echoes the project",
+            mem.get("projectId") == project,
+            f"got {mem.get('projectId')!r}",
+        )
+        # The client sends the enum as an int; the API answers with its name.
+        # If that mapping drifts, memories are stored as the wrong type and
+        # nothing errors.
+        check(
+            "memory_type=2 stores as MEMORY_TYPE_SEMANTIC",
+            mem.get("type") == "MEMORY_TYPE_SEMANTIC",
+            f"got {mem.get('type')!r}",
+        )
+
+    section("3. Query")
+    q = await attempt("query() completes", c.query(query="end-to-end probe", project_id=project))
+    if q is not None:
+        results = q.get("results", [])
+        check("query() finds the stored memory", len(results) > 0, f"got {len(results)} results")
+        if results:
+            check(
+                "query() returns the memory that was stored",
+                results[0].get("memory", {}).get("id") == stored_id,
+                f"got {results[0].get('memory', {}).get('id')!r}",
+            )
+
+    section("4. Profile")
+    p = await attempt("get_profile() completes", c.get_profile(project))
+    if p is not None:
+        check("get_profile() returns an object", isinstance(p, dict), f"got {type(p).__name__}")
+
+    section("5. Connect and graph")
+    s2 = await attempt(
+        "a second store for the edge",
+        c.store(content="MCP probe, related memory", project_id=project, memory_type=2),
+    )
+    second_id = (s2 or {}).get("memory", {}).get("id")
+    if stored_id and second_id:
+        conn = await attempt(
+            "connect() completes",
+            c.connect(from_id=stored_id, to_id=second_id, relationship=1),
+        )
+        check("connect() returns a result", conn is not None)
+
+        g = await attempt("get_graph() completes", c.get_graph(stored_id, depth=2))
+        if g is not None:
+            nodes = g.get("nodes", [])
+            check("get_graph() returns nodes", len(nodes) > 0, f"got {len(nodes)}")
+            check(
+                "get_graph() includes the connected memory",
+                any(n.get("id") == second_id for n in nodes),
+                f"ids: {[n.get('id') for n in nodes][:4]}",
+            )
+
+    section("6. Extract")
+    e = await attempt(
+        "extract() completes",
+        c.extract(
+            conversation="User: I prefer dark mode.\nAssistant: Noted, dark mode it is.",
+            project_id=project,
+        ),
+    )
+    if e is not None:
+        check("extract() returns an object", isinstance(e, dict), f"got {type(e).__name__}")
+
+    section("7. Delete")
+    if stored_id:
+        # delete() returns None on success, so absence of an exception is the
+        # signal; the real check is that the memory stops coming back.
+        await attempt("delete() completes", c.delete(stored_id))
+        after = await attempt("query() after delete", c.query(query="end-to-end probe", project_id=project))
+        if after is not None:
+            ids = [r.get("memory", {}).get("id") for r in after.get("results", [])]
+            check("the deleted memory is gone", stored_id not in ids, f"still present in {ids}")
+
+    section("8. Authentication is enforced")
+    bad = KoraClient(base_url=URL, api_key="ctx0_definitely_not_a_real_key")
+    try:
+        await bad.health()
+        # /v1/health is deliberately reachable; the check is that a write is not.
+        try:
+            await bad.store(content="should not be stored", project_id=project, memory_type=2)
+            check("a bad key is rejected on write", False, "the store succeeded")
+        except Exception:  # noqa: BLE001
+            check("a bad key is rejected on write", True)
+    except Exception:  # noqa: BLE001
+        check("a bad key is rejected on write", True)
+    finally:
+        await bad.close()
+
+    section("9. Pre-rename environment variables warn")
+    # The engine refuses to start on CONTEXT0_*; this package warns. Without
+    # this, a user carrying an old config gets a client pointed at localhost
+    # with no key and no explanation.
+    #
+    # Constructing a client is what exercises it, rather than calling
+    # warn_renamed_env directly: calling the helper only proves the helper
+    # works, and would still pass if nothing ever called it. Verified by
+    # deleting the call from __init__ and watching this fail.
+    os.environ["CONTEXT0_URL"] = "http://old-host:8080"
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            probe = KoraClient(base_url=URL, api_key=KEY)
+        await probe.close()
+        msgs = [str(w.message) for w in caught]
+        check(
+            "constructing a client warns about CONTEXT0_URL",
+            any("CONTEXT0_URL" in m for m in msgs),
+            f"warnings: {msgs}",
+        )
+        check(
+            "the warning names the replacement",
+            any("KORA_HTTP_URL" in m for m in msgs),
+            f"warnings: {msgs}",
+        )
+        # The helper's return value is what a caller would branch on.
+        check("warn_renamed_env reports the name", "CONTEXT0_URL" in warn_renamed_env())
+    finally:
+        del os.environ["CONTEXT0_URL"]
+
+    # Keeps the checks above from passing by warning about everything.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        clean = KoraClient(base_url=URL, api_key=KEY)
+    await clean.close()
+    check("a clean environment warns about nothing", len(caught) == 0, f"got {[str(w.message) for w in caught]}")
+
+    await c.close()
+    return 0
+
+
+def main():
+    if not KEY:
+        print("KORA_API_KEY is required", file=sys.stderr)
+        return 1
+
+    rc = asyncio.run(run())
+    if rc != 0:
+        return rc
+
+    print(f"\n=== {PASSED} passed, {FAILED} failed ===")
+    for f in FAILURES:
+        print(f"  failed: {f}")
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Picks up #6, open since April, after checking it still functions rather than judging it by age: the package installed cleanly and its client round-tripped health, store, and query against the engine at `main`. Every route it calls still exists. What it needed was a rename and a reason to trust it, not a rewrite.

**Renamed for Kora.** It predated the rename and read `CONTEXT0_URL`, `CONTEXT0_API_KEY`, `CONTEXT0_PROJECT` — the names the engine now *refuses to start on*. It reads `KORA_HTTP_URL`, `KORA_API_KEY`, `KORA_PROJECT` now, matching the benchmark scripts and CLI, and warns on the old ones like the CLI does. Warning rather than raising is deliberate: an MCP server is launched by an editor, so a hard failure shows up as a tool that silently never appears.

**Tests, where there were none.** 440 lines with its own route table, its own response parsing, and a mapping from words like "semantic" to wire enum values — none of it checked. The suite runs against a live engine, mirrors `sdk/python/tests/test_e2e.py`, and covers all eight client methods, the enum mapping, auth enforcement on writes, and the rename guard. **18 checks, all passing.**

Two were confirmed load-bearing by breaking what they guard: pointing `/v1/memories/query` at a nonexistent route fails two checks, and deleting the guard call from the constructor fails two more. The rename check originally called `warn_renamed_env` directly, which would have passed even if nothing called it; it constructs a client now.

**Packaging** moved from poetry-core to setuptools, matching `sdk/python`, and the 1,980-line `poetry.lock` is gone. Dependabot's pip ecosystem reads `pyproject.toml`, so that lock was updated by nothing — the directory had no dependency coverage. It has an entry now.

Also removes `ctx0_dev_key_1` from the README's editor config examples. That key was published in a public repo and removed from the chart in a83af5a; this file was handing it to every new user as the value to paste into Claude Code.

Closes #6.