### PR TITLE
Extraction: state the kind, not the way it was said

### DIFF
--- a/internal/extraction/llm.go
+++ b/internal/extraction/llm.go
@@ -75,6 +75,11 @@ on its own, months later, with none of this conversation available:
   has no idea which week.
 - Keep the qualifiers that make a fact answerable. "counseling for transgender
   people" is a different fact from "counseling".
+- When a line says what kind, style or type of something someone does, makes or
+  likes, state that directly: "Caroline makes abstract art", not "Caroline has
+  been trying out abstract painting recently". The kind is the answerable part,
+  and burying it in how it was said leaves a memory that is about the right
+  subject and answers nothing.
 - Merge statements that describe one fact into a single memory.
 - Skip greetings, acknowledgements, questions, and anything with no lasting value.
 - Record what was said as fact, not that a sentence was uttered.


### PR DESCRIPTION
Refs #72. **Draft: one case, not a result.**

The diagnosis in #72 established that 13 of 22 single-hop failures are memories that exist and are never retrieved, and that the cause is not fixable by ranking - the vector retriever already puts the answering memory third, fusion puts it 27th, and both rank fusion and MMR were implemented, measured and rejected because every memory above it is genuinely on topic.

This takes the other route: make the memory answerable at write time.

    old:  Caroline has been trying out abstract painting recently.
    new:  Caroline makes abstract art.

Verified on the exact session that produced the failing memory. The query that returned the old phrasing 27th returns the new one **first**, with no ranking change.

## Why this is a draft

The 200-question run that would confirm or refute it completed ingest and search and then hit `403 PERMISSION_DENIED` on the answering model - the Gemini project is blocked, not rate limited. `kora-200-extract` resumes with the same run id when access returns, and needs only answer + judge, about 20 minutes.

Until that runs, this is a change to how every memory in the store is phrased, justified by one case. That is not enough for main.

## What the run has to show

- Single-hop above 0.450, since that is the category the change targets
- No regression in adversarial (0.925), the control: a rule that pushes toward flat declarative statements could erode the engine’s willingness to refuse
- Per-question labels and McNemar against `kora-locomo-200`, keeping it only if the discordant pairs favour it - the same bar #55 failed