### PR TITLE
Say which retrieval backends are actually running

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,32 @@ in `internal/graph/age.go`.
 - [Helm](https://helm.sh/) 3.x
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 
+### Retrieval quality: the defaults are a floor
+
+A fresh install runs the zero-dependency backends: hashed bag-of-words
+embeddings and a line-by-line rule extractor. Nothing leaves your cluster,
+which is the point, and retrieval finds paraphrases poorly because those
+vectors score token overlap rather than meaning.
+
+The engine says so rather than leaving you to find out. It warns at startup,
+and `/v1/health` reports both backends:
+
+```json
+{"status":"ok","embeddingProvider":"bag-of-words","extractionProvider":"rule","zeroDependencyDefaults":true}
+```
+
+For real embeddings without sending anything outside the cluster, install with
+the quality profile, which points at an Ollama you run:
+
+```bash
+helm install kora ./charts/kora -n kora --create-namespace \
+  -f ./charts/kora/values-quality.yaml \
+  --set postgres.password="..." --set auth.apiKeys="..."
+```
+
+See [charts/kora/values-quality.yaml](charts/kora/values-quality.yaml) for what
+it changes and what it costs on the write path.
+
 ### Install with Helm
 
 ```bash

--- a/api/gen/kora/v1/health.pb.go
+++ b/api/gen/kora/v1/health.pb.go
@@ -75,9 +75,29 @@ type HealthResponse struct {
 	// Total number of memory nodes currently stored in the graph.
 	NodeCount int64 `protobuf:"varint,3,opt,name=node_count,json=nodeCount,proto3" json:"node_count,omitempty"`
 	// Total number of edges currently stored in the graph.
-	EdgeCount     int64 `protobuf:"varint,4,opt,name=edge_count,json=edgeCount,proto3" json:"edge_count,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EdgeCount int64 `protobuf:"varint,4,opt,name=edge_count,json=edgeCount,proto3" json:"edge_count,omitempty"`
+	// Embedding backend in use, as configured: "bag-of-words", "ollama",
+	// "openai" or "google".
+	//
+	// Reported because the default is "bag-of-words", a hashed bag-of-words with
+	// no notion of meaning. It is the right default -- no network egress on a
+	// fresh install -- but a deployment running it retrieves paraphrases far
+	// worse than one with a real model, and nothing else says so.
+	EmbeddingProvider string `protobuf:"bytes,5,opt,name=embedding_provider,json=embeddingProvider,proto3" json:"embedding_provider,omitempty"`
+	// Extraction backend in use: "rule" or "llm".
+	//
+	// The default "rule" classifies line by line and cannot merge facts spread
+	// across turns. Same reasoning as embedding_provider: a caller comparing two
+	// deployments should be able to see which one is answering.
+	ExtractionProvider string `protobuf:"bytes,6,opt,name=extraction_provider,json=extractionProvider,proto3" json:"extraction_provider,omitempty"`
+	// True when both providers are the zero-dependency defaults, so retrieval
+	// quality is a floor rather than a measure of what the engine can do.
+	//
+	// A field rather than a status of "degraded": the engine is healthy, and a
+	// monitoring system that pages on this would be wrong.
+	ZeroDependencyDefaults bool `protobuf:"varint,7,opt,name=zero_dependency_defaults,json=zeroDependencyDefaults,proto3" json:"zero_dependency_defaults,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *HealthResponse) Reset() {
@@ -138,19 +158,43 @@ func (x *HealthResponse) GetEdgeCount() int64 {
 	return 0
 }
 
+func (x *HealthResponse) GetEmbeddingProvider() string {
+	if x != nil {
+		return x.EmbeddingProvider
+	}
+	return ""
+}
+
+func (x *HealthResponse) GetExtractionProvider() string {
+	if x != nil {
+		return x.ExtractionProvider
+	}
+	return ""
+}
+
+func (x *HealthResponse) GetZeroDependencyDefaults() bool {
+	if x != nil {
+		return x.ZeroDependencyDefaults
+	}
+	return false
+}
+
 var File_kora_v1_health_proto protoreflect.FileDescriptor
 
 const file_kora_v1_health_proto_rawDesc = "" +
 	"\n" +
 	"\x14kora/v1/health.proto\x12\akora.v1\x1a\x1cgoogle/api/annotations.proto\"\x0f\n" +
-	"\rHealthRequest\"\x80\x01\n" +
+	"\rHealthRequest\"\x9a\x02\n" +
 	"\x0eHealthResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x1d\n" +
 	"\n" +
 	"node_count\x18\x03 \x01(\x03R\tnodeCount\x12\x1d\n" +
 	"\n" +
-	"edge_count\x18\x04 \x01(\x03R\tedgeCount2^\n" +
+	"edge_count\x18\x04 \x01(\x03R\tedgeCount\x12-\n" +
+	"\x12embedding_provider\x18\x05 \x01(\tR\x11embeddingProvider\x12/\n" +
+	"\x13extraction_provider\x18\x06 \x01(\tR\x12extractionProvider\x128\n" +
+	"\x18zero_dependency_defaults\x18\a \x01(\bR\x16zeroDependencyDefaults2^\n" +
 	"\rHealthService\x12M\n" +
 	"\x06Health\x12\x16.kora.v1.HealthRequest\x1a\x17.kora.v1.HealthResponse\"\x12\x82\xd3\xe4\x93\x02\f\x12\n" +
 	"/v1/healthB7Z5github.com/NarayanaSabari/Kora/api/gen/kora/v1;korav1b\x06proto3"

--- a/api/gen/kora/v1/memory.pb.go
+++ b/api/gen/kora/v1/memory.pb.go
@@ -625,6 +625,9 @@ type QueryRequest struct {
 	// Project to search within.
 	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Maximum number of results to return.
+	//
+	// Defaults to 5 when unset or zero, and is clamped to 200. A request above
+	// the maximum returns 200 results rather than an error.
 	TopK int32 `protobuf:"varint,3,opt,name=top_k,json=topK,proto3" json:"top_k,omitempty"`
 	// Maximum graph traversal depth for context edges (0 = no traversal).
 	MaxDepth int32 `protobuf:"varint,4,opt,name=max_depth,json=maxDepth,proto3" json:"max_depth,omitempty"`

--- a/api/proto/kora/v1/health.proto
+++ b/api/proto/kora/v1/health.proto
@@ -39,4 +39,27 @@ message HealthResponse {
 
   // Total number of edges currently stored in the graph.
   int64 edge_count = 4;
+
+  // Embedding backend in use, as configured: "bag-of-words", "ollama",
+  // "openai" or "google".
+  //
+  // Reported because the default is "bag-of-words", a hashed bag-of-words with
+  // no notion of meaning. It is the right default -- no network egress on a
+  // fresh install -- but a deployment running it retrieves paraphrases far
+  // worse than one with a real model, and nothing else says so.
+  string embedding_provider = 5;
+
+  // Extraction backend in use: "rule" or "llm".
+  //
+  // The default "rule" classifies line by line and cannot merge facts spread
+  // across turns. Same reasoning as embedding_provider: a caller comparing two
+  // deployments should be able to see which one is answering.
+  string extraction_provider = 6;
+
+  // True when both providers are the zero-dependency defaults, so retrieval
+  // quality is a floor rather than a measure of what the engine can do.
+  //
+  // A field rather than a status of "degraded": the engine is healthy, and a
+  // monitoring system that pages on this would be wrong.
+  bool zero_dependency_defaults = 7;
 }

--- a/charts/kora/templates/api.yaml
+++ b/charts/kora/templates/api.yaml
@@ -96,6 +96,47 @@ spec:
             # value times .Values.api.replicas.
             - name: KORA_RATE_LIMIT_PER_MINUTE
               value: {{ .Values.api.rateLimitPerMinute | quote }}
+            # Retrieval backends. Always set, including at their defaults, so
+            # `kubectl describe` answers "what is this deployment actually
+            # running" without a chart lookup.
+            - name: KORA_EMBEDDING_PROVIDER
+              value: {{ .Values.embedding.provider | quote }}
+            {{- if .Values.embedding.model }}
+            - name: KORA_EMBEDDING_MODEL
+              value: {{ .Values.embedding.model | quote }}
+            {{- end }}
+            {{- if .Values.embedding.baseUrl }}
+            - name: KORA_EMBEDDING_BASE_URL
+              value: {{ .Values.embedding.baseUrl | quote }}
+            {{- end }}
+            {{- if .Values.embedding.dim }}
+            - name: KORA_EMBEDDING_DIM
+              value: {{ .Values.embedding.dim | quote }}
+            {{- end }}
+            {{- if .Values.embedding.existingSecret }}
+            - name: KORA_EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.embedding.existingSecret }}
+                  key: {{ .Values.embedding.existingSecretKey }}
+            {{- end }}
+            - name: KORA_EXTRACTION_PROVIDER
+              value: {{ .Values.extraction.provider | quote }}
+            {{- if .Values.extraction.model }}
+            - name: KORA_EXTRACTION_MODEL
+              value: {{ .Values.extraction.model | quote }}
+            {{- end }}
+            {{- if .Values.extraction.baseUrl }}
+            - name: KORA_EXTRACTION_BASE_URL
+              value: {{ .Values.extraction.baseUrl | quote }}
+            {{- end }}
+            {{- if .Values.extraction.existingSecret }}
+            - name: KORA_EXTRACTION_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.extraction.existingSecret }}
+                  key: {{ .Values.extraction.existingSecretKey }}
+            {{- end }}
             - name: KORA_LOG_LEVEL
               value: {{ .Values.api.logLevel | quote }}
             - name: KORA_LOG_FORMAT

--- a/charts/kora/values-quality.yaml
+++ b/charts/kora/values-quality.yaml
@@ -1,0 +1,54 @@
+# Quality profile: real embeddings and LLM extraction, still inside the cluster.
+#
+#   helm install kora ./charts/kora -n kora --create-namespace \
+#     -f ./charts/kora/values-quality.yaml \
+#     --set postgres.password=... --set auth.apiKeys=...
+#
+# The chart's defaults are the zero-dependency ones, so a fresh install makes
+# no network call and stores nothing outside the cluster. They also retrieve
+# paraphrases poorly: hashed bag-of-words vectors score token overlap, not
+# meaning, and the rule-based extractor cannot merge a fact stated across two
+# turns. The engine warns about this at startup and reports both providers on
+# /v1/health.
+#
+# This file changes both, pointing at an Ollama you run yourself. That keeps
+# the property the defaults exist to protect -- nothing leaves the cluster --
+# while giving retrieval a model that understands that "abstract painting" and
+# "art" are related.
+#
+# It assumes Ollama is reachable at ollama.ollama.svc.cluster.local:11434 with
+# the two models pulled:
+#
+#   ollama pull nomic-embed-text
+#   ollama pull llama3.1
+#
+# For a hosted provider instead, set embedding.provider to "openai" or
+# "google", leave baseUrl empty, and point existingSecret at a Secret holding
+# the key. Note that this sends memory content to that provider, which is the
+# trade the defaults exist to avoid making silently.
+
+embedding:
+  provider: "ollama"
+  model: "nomic-embed-text"
+  baseUrl: "http://ollama.ollama.svc.cluster.local:11434"
+  # nomic-embed-text is 768-wide. Set explicitly rather than auto-detected,
+  # because the embeddings column is created at the width first seen and a
+  # surprise here means a re-embed rather than an error.
+  dim: 768
+
+extraction:
+  provider: "llm"
+  model: "llama3.1"
+  # Ollama serves an OpenAI-compatible API at /v1, which is what the extractor
+  # speaks. No API key: a local Ollama does not ask for one.
+  baseUrl: "http://ollama.ollama.svc.cluster.local:11434/v1"
+
+# Extraction runs a model call per session on the write path, so ingest is
+# slower and the pool holds connections longer. Measured on LoCoMo transcripts:
+# roughly 25 seconds per session against a local model, against milliseconds
+# for the rule-based scanner.
+api:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/charts/kora/values.yaml
+++ b/charts/kora/values.yaml
@@ -1,6 +1,45 @@
 # Kora Helm Chart values
 
 # API Server
+# Retrieval quality: which embedding and extraction backends the engine uses.
+#
+# The defaults are the zero-dependency ones. Hashed bag-of-words embeddings
+# make no network call and understand no meaning, and the rule-based extractor
+# classifies line by line and cannot merge a fact stated across two turns. That
+# is the right default for a fresh install -- nothing leaves the cluster until
+# an operator says so -- but it is a floor on retrieval quality, not a measure
+# of it.
+#
+# `helm install -f charts/kora/values-quality.yaml` switches both to a local
+# Ollama, which keeps the no-egress property while giving real embeddings.
+# The engine warns at startup and reports both providers on /v1/health when
+# these are left at their defaults.
+embedding:
+  # "bag-of-words" | "ollama" | "openai" | "google"
+  provider: "bag-of-words"
+  # Model name, e.g. "nomic-embed-text" for Ollama.
+  model: ""
+  # Endpoint override, e.g. "http://ollama.ollama.svc.cluster.local:11434".
+  baseUrl: ""
+  # Vector dimension. 0 auto-detects from the provider. Changing this on a
+  # deployment that already holds embeddings needs a re-embed: the column is
+  # created at the width first seen.
+  dim: 0
+  # Secret holding the provider API key, for openai and google. Cloud providers
+  # refuse to start without one.
+  existingSecret: ""
+  existingSecretKey: "api-key"
+
+extraction:
+  # "rule" | "llm"
+  provider: "rule"
+  # Chat model, required by "llm".
+  model: ""
+  # OpenAI-compatible endpoint, required by "llm". Ollama serves one at /v1.
+  baseUrl: ""
+  existingSecret: ""
+  existingSecretKey: "api-key"
+
 api:
   replicas: 1
   image:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -135,6 +135,25 @@ func main() {
 	}
 	slog.Info("extraction provider ready", slog.String("provider", cfg.ExtractionProvider))
 
+	// Both providers on their defaults is a supported configuration and a quiet
+	// one: the engine starts, answers, and retrieves paraphrases far worse than
+	// the same corpus would with a real embedding model. Nothing fails, so
+	// nothing would otherwise say so, and the first symptom is a benchmark
+	// number or a user wondering why a question they can answer from the
+	// transcript comes back empty.
+	//
+	// Not fatal, and not a "degraded" health status: no network egress on a
+	// fresh install is the right default, and paging on it would be wrong.
+	// Loud once, at startup, where an operator is looking.
+	providers := service.Providers{Embedding: cfg.EmbeddingProvider, Extraction: cfg.ExtractionProvider}
+	if providers.ZeroDependencyDefaults() {
+		slog.Warn("running on zero-dependency defaults: hashed bag-of-words embeddings and rule-based extraction",
+			slog.String("embedding_provider", cfg.EmbeddingProvider),
+			slog.String("extraction_provider", cfg.ExtractionProvider),
+			slog.String("effect", "retrieval finds paraphrases poorly and extraction cannot merge facts across turns"),
+			slog.String("fix", "set KORA_EMBEDDING_PROVIDER and KORA_EXTRACTION_PROVIDER, or install the chart with charts/kora/values-quality.yaml"))
+	}
+
 	// Step 4: Create the graph repository and apply schema migrations.
 	repo := graph.NewAGERepository(pool, embedder.Dimension())
 	if err := repo.InitSchema(ctx); err != nil {
@@ -163,7 +182,7 @@ func main() {
 	// Register all service implementations on the gRPC server.
 	memorySvc := service.NewMemoryServiceWithExtractor(repo, embedder, extractor)
 	sessionSvc := service.NewSessionService(repo)
-	healthSvc := service.NewHealthService(repo, cfg.Version)
+	healthSvc := service.NewHealthService(repo, cfg.Version, providers)
 
 	pb.RegisterKoraServer(grpcServer, memorySvc)
 	pb.RegisterSessionServiceServer(grpcServer, sessionSvc)

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -56,10 +56,34 @@ type healthRepo interface {
 }
 
 // HealthService implements the HealthService gRPC service.
+// Providers names the backends the engine is actually running, for reporting.
+//
+// Reported because the defaults are the zero-dependency ones -- hashed
+// bag-of-words embeddings and a line-by-line rule extractor -- and a
+// deployment running them retrieves paraphrases far worse than one with a real
+// model. That is the right default, since a fresh install should make no
+// network call, but it should not be invisible: the same corpus scores very
+// differently depending on which of these is in use, and someone comparing two
+// deployments needs to know which they are looking at.
+type Providers struct {
+	Embedding  string
+	Extraction string
+}
+
+// ZeroDependencyDefaults reports whether both providers are the offline
+// defaults. Empty counts as default, because that is what an unset environment
+// variable produces.
+func (p Providers) ZeroDependencyDefaults() bool {
+	embedding := p.Embedding == "" || p.Embedding == "bag-of-words" || p.Embedding == "bow"
+	extraction := p.Extraction == "" || p.Extraction == "rule"
+	return embedding && extraction
+}
+
 type HealthService struct {
 	pb.UnimplementedHealthServiceServer
-	repo    healthRepo
-	version string
+	repo      healthRepo
+	version   string
+	providers Providers
 
 	// group collapses concurrent recomputes into one. Without it, N clients
 	// arriving on an expired cache each launch their own pair of full scans,
@@ -81,8 +105,8 @@ type graphStats struct {
 
 // NewHealthService creates a new HealthService with the given graph repository
 // and server version string. The version is returned verbatim in responses.
-func NewHealthService(repo *graph.AGERepository, version string) *HealthService {
-	return &HealthService{repo: repo, version: version}
+func NewHealthService(repo *graph.AGERepository, version string, providers Providers) *HealthService {
+	return &HealthService{repo: repo, version: version, providers: providers}
 }
 
 // Health reports service status and graph statistics.
@@ -114,10 +138,13 @@ func (s *HealthService) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.He
 	}
 
 	return &pb.HealthResponse{
-		Status:    "ok",
-		Version:   s.version,
-		NodeCount: stats.nodes,
-		EdgeCount: stats.edges,
+		Status:                 "ok",
+		Version:                s.version,
+		NodeCount:              stats.nodes,
+		EdgeCount:              stats.edges,
+		EmbeddingProvider:      s.providers.Embedding,
+		ExtractionProvider:     s.providers.Extraction,
+		ZeroDependencyDefaults: s.providers.ZeroDependencyDefaults(),
 	}, nil
 }
 

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -395,3 +395,51 @@ func TestHealthStatsRecomputeIsBounded(t *testing.T) {
 		t.Errorf("statsTimeout is %s, too long to bound a health check", statsTimeout)
 	}
 }
+
+// A deployment on the zero-dependency defaults must say so.
+//
+// The defaults are the right ones -- a fresh install makes no network call --
+// but they are a floor on retrieval quality, not a measure of it, and the
+// engine answers happily either way. Health is where an operator asks "what is
+// this actually running", so the answer has to be there rather than inferred
+// from a chart or an environment variable they cannot see.
+func TestHealth_ReportsWhichBackendsAreRunning(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers Providers
+		wantZero  bool
+	}{
+		{"offline defaults", Providers{Embedding: "bag-of-words", Extraction: "rule"}, true},
+		// Unset is the same state: an operator who set nothing gets the
+		// defaults, and the warning has to fire for them too.
+		{"unset", Providers{}, true},
+		{"the alias for the default embedder", Providers{Embedding: "bow", Extraction: "rule"}, true},
+		{"real embedder, default extractor", Providers{Embedding: "ollama", Extraction: "rule"}, false},
+		{"default embedder, real extractor", Providers{Embedding: "bag-of-words", Extraction: "llm"}, false},
+		{"both real", Providers{Embedding: "google", Extraction: "llm"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.providers.ZeroDependencyDefaults(); got != tt.wantZero {
+				t.Errorf("ZeroDependencyDefaults() = %v, want %v for %+v", got, tt.wantZero, tt.providers)
+			}
+		})
+	}
+}
+
+// The reported names are the ones configured, not a guess reconstructed from
+// what happens to be reachable.
+func TestHealth_ProviderNamesSurviveToTheResponse(t *testing.T) {
+	svc := &HealthService{
+		version:   "test",
+		providers: Providers{Embedding: "ollama", Extraction: "llm"},
+	}
+
+	if svc.providers.Embedding != "ollama" || svc.providers.Extraction != "llm" {
+		t.Fatalf("providers not held as given: %+v", svc.providers)
+	}
+	if svc.providers.ZeroDependencyDefaults() {
+		t.Error("a deployment running Ollama and an LLM extractor is not on zero-dependency defaults")
+	}
+}


### PR DESCRIPTION
Closes #59.

A fresh install runs hashed bag-of-words embeddings and the rule-based extractor, and nothing said so. The same corpus scores very differently depending on which backends are in use - the 200-question LoCoMo runs use Gemini embeddings and LLM extraction, and a default `helm install` gets neither.

Three places, chosen so the answer is where someone is already looking:

**Startup warning**, once at boot:

```
level=WARN msg="running on zero-dependency defaults: hashed bag-of-words embeddings and rule-based extraction"
  embedding_provider=bag-of-words extraction_provider=rule
  effect="retrieval finds paraphrases poorly and extraction cannot merge facts across turns"
  fix="set KORA_EMBEDDING_PROVIDER and KORA_EXTRACTION_PROVIDER, or install the chart with charts/kora/values-quality.yaml"
```

**`/v1/health`** gains `embedding_provider`, `extraction_provider` and `zero_dependency_defaults`.

**The chart** had no embedding or extraction values at all, so the quality path was unreachable through Helm. It has them now, plus `values-quality.yaml` pointing both at a local Ollama - which keeps the property the defaults exist to protect (nothing leaves the cluster) while giving retrieval a model that understands `abstract painting` and `art` are related. That last part is not hypothetical: it is the failure in #72.

## Judgement calls

**Not a `degraded` status, and not fatal.** The engine is healthy; a monitoring system paging on this would be wrong. Refusing to start would break the fresh-install path the defaults exist to serve.

**Providers are reported as configured, not probed.** The name is what the operator asked for, which is the question they are asking.

**Empty counts as default** in `ZeroDependencyDefaults()`, because an unset environment variable is exactly how most people arrive at the defaults, and the warning has to fire for them too.

Verified: `helm template` with and without the profile emits the right env, `helm lint` passes both, `scripts/verify_docs.sh` still passes (it now checks the new settings exist in code), full `go test ./...` green.