### PR TITLE
State what an API key actually grants

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,12 +28,42 @@ Instead, please email: **security@kora.dev** (or open a private security advisor
 | 0.x.x (latest) | Yes |
 | Older versions | No |
 
+## What an API key grants
+
+**One Kora deployment is one trust domain.** An API key is not scoped to a
+project: any valid key can read, write and delete every memory the deployment
+holds, in every project.
+
+This is deliberate rather than an oversight, and it is recorded in
+[ADR 0002](docs/adr/0002-one-deployment-is-one-trust-domain.md). Kora's value
+comes from agents sharing what they learn, and the self-hosted deployment model
+already puts the boundary at the cluster: whoever installs the chart decides
+who gets a key. Per-project keys would add an authorisation model to every call
+path in exchange for a boundary the deployment topology already provides.
+
+Two consequences worth stating plainly:
+
+- **Projects organise retrieval; they do not isolate it.** `project_id` decides
+  which memories a query searches, not which memories a caller is allowed to
+  see. A caller who omits it queries across every project in the deployment,
+  which is the documented behaviour of `GET /v1/memories/query`.
+- **Separate trust domains need separate deployments.** That is the supported
+  answer and it is cheap here: one chart install and one database per domain.
+  Do not hand a key for a shared deployment to a party that should not read
+  everything in it.
+
+If you need multi-tenant isolation within one deployment, it is a real feature
+with its own design -- key-to-project binding, a project-scoped query path, and
+audit -- rather than a configuration flag. Say so in an issue rather than
+assuming a per-project key exists.
+
 ## Security Practices
 
 Kora follows these security practices:
 
 - **No hardcoded secrets**: all credentials via environment variables or K8s Secrets
-- **API key authentication**: with token bucket rate limiting
+- **API key authentication**: with token bucket rate limiting, deployment-wide
+  in scope (see [What an API key grants](#what-an-api-key-grants))
 - **Input validation**: on all API endpoints
 - **SQL injection prevention**: parameterized queries (pgx) + Cypher escaping
 - **Dependency scanning**: automated via CI (trivy, gosec)

--- a/api/gen/kora/v1/memory.pb.go
+++ b/api/gen/kora/v1/memory.pb.go
@@ -158,6 +158,9 @@ type Memory struct {
 	// Cognitive category of this memory.
 	Type MemoryType `protobuf:"varint,3,opt,name=type,proto3,enum=kora.v1.MemoryType" json:"type,omitempty"`
 	// Identifier of the project this memory is scoped to.
+	//
+	// Organises retrieval; it is not a security boundary. Every API key in a
+	// deployment can read every project in it. See SECURITY.md.
 	ProjectId string `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Free-form labels for filtering and categorization.
 	Tags []string `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"`
@@ -497,6 +500,8 @@ type StoreRequest struct {
 	// Cognitive category of the memory.
 	Type MemoryType `protobuf:"varint,2,opt,name=type,proto3,enum=kora.v1.MemoryType" json:"type,omitempty"`
 	// Project to scope this memory to.
+	//
+	// Required. Organises retrieval rather than isolating it: see SECURITY.md.
 	ProjectId string `protobuf:"bytes,3,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Optional free-form labels for categorization.
 	Tags []string `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"`
@@ -623,6 +628,16 @@ type QueryRequest struct {
 	// Natural-language query string used for vector similarity search.
 	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 	// Project to search within.
+	//
+	// Optional. An empty value searches every project in the deployment, which
+	// is a scoping decision and not an authorisation one: an API key is not
+	// bound to a project, so any valid key can already read all of them. One
+	// deployment is one trust domain -- see
+	// docs/adr/0002-one-deployment-is-one-trust-domain.md and SECURITY.md.
+	//
+	// Prefer setting it. Entity retrieval is scoped per project and does not run
+	// without one, so an unscoped query is answered by fewer retrievers than a
+	// scoped one, and it ranks over the whole store.
 	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Maximum number of results to return.
 	//
@@ -1071,6 +1086,8 @@ type ExtractRequest struct {
 	// Raw conversation text (multi-turn messages) to extract knowledge from.
 	Conversation string `protobuf:"bytes,1,opt,name=conversation,proto3" json:"conversation,omitempty"`
 	// Project to scope the extracted memories to.
+	//
+	// Required. Organises retrieval rather than isolating it: see SECURITY.md.
 	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Optional session ID to link extracted memories to.
 	SessionId     string `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -1190,6 +1207,8 @@ func (x *ExtractResponse) GetRelationshipsCreated() int32 {
 type GetProfileRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Project to build the profile for.
+	//
+	// Required. Organises retrieval rather than isolating it: see SECURITY.md.
 	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Optional query string to filter the profile by relevance.
 	Query         string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`

--- a/api/proto/kora/v1/memory.proto
+++ b/api/proto/kora/v1/memory.proto
@@ -118,6 +118,9 @@ message Memory {
   MemoryType type = 3;
 
   // Identifier of the project this memory is scoped to.
+  //
+  // Organises retrieval; it is not a security boundary. Every API key in a
+  // deployment can read every project in it. See SECURITY.md.
   string project_id = 4;
 
   // Free-form labels for filtering and categorization.
@@ -196,6 +199,8 @@ message StoreRequest {
   MemoryType type = 2;
 
   // Project to scope this memory to.
+  //
+  // Required. Organises retrieval rather than isolating it: see SECURITY.md.
   string project_id = 3;
 
   // Optional free-form labels for categorization.
@@ -219,6 +224,16 @@ message QueryRequest {
   string query = 1;
 
   // Project to search within.
+  //
+  // Optional. An empty value searches every project in the deployment, which
+  // is a scoping decision and not an authorisation one: an API key is not
+  // bound to a project, so any valid key can already read all of them. One
+  // deployment is one trust domain -- see
+  // docs/adr/0002-one-deployment-is-one-trust-domain.md and SECURITY.md.
+  //
+  // Prefer setting it. Entity retrieval is scoped per project and does not run
+  // without one, so an unscoped query is answered by fewer retrievers than a
+  // scoped one, and it ranks over the whole store.
   string project_id = 2;
 
   // Maximum number of results to return.
@@ -307,6 +322,8 @@ message ExtractRequest {
   string conversation = 1;
 
   // Project to scope the extracted memories to.
+  //
+  // Required. Organises retrieval rather than isolating it: see SECURITY.md.
   string project_id = 2;
 
   // Optional session ID to link extracted memories to.
@@ -329,6 +346,8 @@ message ExtractResponse {
 // an aggregated user/project profile from stored memories.
 message GetProfileRequest {
   // Project to build the profile for.
+  //
+  // Required. Organises retrieval rather than isolating it: see SECURITY.md.
   string project_id = 1;
 
   // Optional query string to filter the profile by relevance.

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -224,7 +224,9 @@ func (s *MemoryService) Query(ctx context.Context, req *pb.QueryRequest) (*pb.Qu
 	timer := prometheus.NewTimer(metrics.QueryDuration)
 	defer timer.ObserveDuration()
 
-	// project_id is optional — if empty, query across all projects.
+	// project_id is optional: empty searches every project in the deployment.
+	// That is a scoping decision, not an authorisation one -- an API key is not
+	// bound to a project. See docs/adr/0002-one-deployment-is-one-trust-domain.md.
 
 	var types []model.MemoryType
 	for _, t := range req.Types {


### PR DESCRIPTION
Closes #62.

API keys carry no project binding, and `Query` searches every project when `project_id` is empty. Both are deliberate ([ADR 0002](docs/adr/0002-one-deployment-is-one-trust-domain.md)), and neither was visible anywhere an operator or an API consumer would look.

The failure mode is quiet: a reader assumes per-project keys exist, hands one to a party that should not read everything, and nothing corrects them.

**SECURITY.md** gains a section above the practices list - one deployment is one trust domain, projects organise retrieval rather than isolating it, separate trust domains need separate deployments, and isolation within one deployment is a feature with a design rather than a flag.

**The proto** says it at every `project_id`, because that is where someone integrating meets the question. The `QueryRequest` field carries an extra note that an unscoped query is answered by *fewer retrievers* - entity retrieval is scoped per project and does not run without one - so omitting it is worse retrieval as well as wider reach. That is a real behaviour of `internal/retrieval`, not a discouragement.

The stale inline comment in `Query` that called it merely "optional" now points at the ADR too.