### PR TITLE
Profile takes a result cap and a recency window

### DIFF
--- a/api/gen/kora/v1/memory.pb.go
+++ b/api/gen/kora/v1/memory.pb.go
@@ -1192,7 +1192,25 @@ type GetProfileRequest struct {
 	// Project to build the profile for.
 	ProjectId string `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
 	// Optional query string to filter the profile by relevance.
-	Query         string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
+	Query string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
+	// How many of the project's memories to build the profile from.
+	//
+	// Defaults to 200 when unset or zero, and is clamped to 1000. A request
+	// above the maximum returns a profile built from 1000 memories rather than
+	// an error, the same contract as QueryRequest.top_k.
+	//
+	// Memories are taken by the graph query's own order, so raising this widens
+	// the profile rather than reordering it.
+	MaxMemories int32 `protobuf:"varint,3,opt,name=max_memories,json=maxMemories,proto3" json:"max_memories,omitempty"`
+	// How recent a memory must be to count as current rather than settled.
+	//
+	// Defaults to 7 days when unset or zero, and is clamped to 365. Episodic
+	// memories inside the window form the dynamic profile; everything else that
+	// is episodic falls outside it and appears in neither half.
+	//
+	// Parameterised because "recent" is a claim about someone else's product: a
+	// support bot and a coding assistant do not agree on it.
+	RecencyDays   int32 `protobuf:"varint,4,opt,name=recency_days,json=recencyDays,proto3" json:"recency_days,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1239,6 +1257,20 @@ func (x *GetProfileRequest) GetQuery() string {
 		return x.Query
 	}
 	return ""
+}
+
+func (x *GetProfileRequest) GetMaxMemories() int32 {
+	if x != nil {
+		return x.MaxMemories
+	}
+	return 0
+}
+
+func (x *GetProfileRequest) GetRecencyDays() int32 {
+	if x != nil {
+		return x.RecencyDays
+	}
+	return 0
 }
 
 // ProfileFact is a single distilled fact in a user/project profile,
@@ -1456,11 +1488,13 @@ const file_kora_v1_memory_proto_rawDesc = "" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\"s\n" +
 	"\x0fExtractResponse\x12+\n" +
 	"\bmemories\x18\x01 \x03(\v2\x0f.kora.v1.MemoryR\bmemories\x123\n" +
-	"\x15relationships_created\x18\x02 \x01(\x05R\x14relationshipsCreated\"H\n" +
+	"\x15relationships_created\x18\x02 \x01(\x05R\x14relationshipsCreated\"\x8e\x01\n" +
 	"\x11GetProfileRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x12\x14\n" +
-	"\x05query\x18\x02 \x01(\tR\x05query\"\x84\x01\n" +
+	"\x05query\x18\x02 \x01(\tR\x05query\x12!\n" +
+	"\fmax_memories\x18\x03 \x01(\x05R\vmaxMemories\x12!\n" +
+	"\frecency_days\x18\x04 \x01(\x05R\vrecencyDays\"\x84\x01\n" +
 	"\vProfileFact\x12\x18\n" +
 	"\acontent\x18\x01 \x01(\tR\acontent\x12'\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x13.kora.v1.MemoryTypeR\x04type\x12\x1e\n" +

--- a/api/proto/kora/v1/memory.proto
+++ b/api/proto/kora/v1/memory.proto
@@ -333,6 +333,26 @@ message GetProfileRequest {
 
   // Optional query string to filter the profile by relevance.
   string query = 2;
+
+  // How many of the project's memories to build the profile from.
+  //
+  // Defaults to 200 when unset or zero, and is clamped to 1000. A request
+  // above the maximum returns a profile built from 1000 memories rather than
+  // an error, the same contract as QueryRequest.top_k.
+  //
+  // Memories are taken by the graph query's own order, so raising this widens
+  // the profile rather than reordering it.
+  int32 max_memories = 3;
+
+  // How recent a memory must be to count as current rather than settled.
+  //
+  // Defaults to 7 days when unset or zero, and is clamped to 365. Episodic
+  // memories inside the window form the dynamic profile; everything else that
+  // is episodic falls outside it and appears in neither half.
+  //
+  // Parameterised because "recent" is a claim about someone else's product: a
+  // support bot and a coding assistant do not agree on it.
+  int32 recency_days = 4;
 }
 
 // ProfileFact is a single distilled fact in a user/project profile,

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -647,18 +647,60 @@ func (s *MemoryService) Extract(ctx context.Context, req *pb.ExtractRequest) (*p
 // GetProfile builds a user/project profile by splitting all project memories into
 // two layers:
 //   - Static profile: semantic facts and procedural knowledge that are stable over time.
-//   - Dynamic profile: episodic memories from the last 7 days representing recent activity.
+//   - Dynamic profile: episodic memories inside the recency window, defaulting
+//     to the last 7 days, representing recent activity.
 //
 // Each fact carries the memory's current decay score as a confidence indicator.
+// Profile sizing. Both were hardcoded, which made "recent" a claim this engine
+// imposed on every caller: a support bot and a coding assistant do not agree
+// on how long ago something stops being current.
+//
+// The clamps follow the contract top_k settled on -- a request above the
+// maximum is served at the maximum rather than refused -- because a profile is
+// a convenience view and failing one over an ambitious number helps nobody.
+// The maxima exist because both bound real work: the memory budget is a graph
+// query's LIMIT, and a 365-day window with a large budget is the widest profile
+// anyone has asked for.
+const (
+	defaultProfileMemories = 200
+	maxProfileMemories     = 1000
+
+	defaultProfileRecencyDays = 7
+	maxProfileRecencyDays     = 365
+)
+
+// profileMemoryBudget resolves how many memories a profile is built from.
+func profileMemoryBudget(requested int32) int32 {
+	switch {
+	case requested <= 0:
+		return defaultProfileMemories
+	case requested > maxProfileMemories:
+		return maxProfileMemories
+	default:
+		return requested
+	}
+}
+
+// profileRecencyDays resolves the window that separates current from settled.
+func profileRecencyDays(requested int32) int {
+	switch {
+	case requested <= 0:
+		return defaultProfileRecencyDays
+	case requested > maxProfileRecencyDays:
+		return maxProfileRecencyDays
+	default:
+		return int(requested)
+	}
+}
+
 func (s *MemoryService) GetProfile(ctx context.Context, req *pb.GetProfileRequest) (*pb.GetProfileResponse, error) {
 	if req.ProjectId == "" {
 		return nil, status.Error(codes.InvalidArgument, "project_id is required")
 	}
 
-	// Fetch all memories for this project.
 	filter := graph.QueryFilter{
 		ProjectID: req.ProjectId,
-		TopK:      200,
+		TopK:      profileMemoryBudget(req.MaxMemories),
 	}
 	results, err := s.repo.QueryMemories(ctx, filter)
 	if err != nil {
@@ -666,7 +708,7 @@ func (s *MemoryService) GetProfile(ctx context.Context, req *pb.GetProfileReques
 	}
 
 	now := time.Now().UTC()
-	dynamicCutoff := now.AddDate(0, 0, -7) // last 7 days
+	dynamicCutoff := now.AddDate(0, 0, -profileRecencyDays(req.RecencyDays))
 
 	var staticFacts []*pb.ProfileFact
 	var dynamicFacts []*pb.ProfileFact

--- a/internal/service/memory_test.go
+++ b/internal/service/memory_test.go
@@ -700,3 +700,50 @@ func TestExtractLinksSemanticallyRelatedMemories(t *testing.T) {
 			e.TargetContent)
 	}
 }
+
+// A profile's size and its notion of "recent" are the caller's to choose.
+//
+// Both were hardcoded at 200 memories and 7 days, which made this engine's
+// opinion about how long something stays current into everyone's. The clamps
+// follow the contract top_k settled on: a request above the maximum is served
+// at the maximum rather than refused, because a profile is a convenience view
+// and failing one over an ambitious number helps nobody.
+func TestProfileSizing(t *testing.T) {
+	memories := []struct {
+		name      string
+		requested int32
+		want      int32
+	}{
+		{"unset falls back to the documented default", 0, defaultProfileMemories},
+		{"negative is treated as unset, not as an error", -1, defaultProfileMemories},
+		{"a modest request is honoured exactly", 50, 50},
+		{"the maximum is honoured exactly", maxProfileMemories, maxProfileMemories},
+		{"above the maximum is served at the maximum", maxProfileMemories + 5000, maxProfileMemories},
+	}
+	for _, tt := range memories {
+		t.Run("budget/"+tt.name, func(t *testing.T) {
+			if got := profileMemoryBudget(tt.requested); got != tt.want {
+				t.Errorf("profileMemoryBudget(%d) = %d, want %d", tt.requested, got, tt.want)
+			}
+		})
+	}
+
+	days := []struct {
+		name      string
+		requested int32
+		want      int
+	}{
+		{"unset falls back to a week", 0, defaultProfileRecencyDays},
+		{"negative is treated as unset", -30, defaultProfileRecencyDays},
+		{"a day is a legitimate window", 1, 1},
+		{"a year is the maximum", maxProfileRecencyDays, maxProfileRecencyDays},
+		{"beyond a year is served at a year", 4000, maxProfileRecencyDays},
+	}
+	for _, tt := range days {
+		t.Run("recency/"+tt.name, func(t *testing.T) {
+			if got := profileRecencyDays(tt.requested); got != tt.want {
+				t.Errorf("profileRecencyDays(%d) = %d, want %d", tt.requested, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #63.

`GetProfile` fetched a fixed 200 memories and treated anything episodic from the last 7 days as "current". The window is the part that matters: it is a claim about someone else’s product, and a support bot and a coding assistant do not agree on how long ago something stops being current.

`GetProfileRequest` gains `max_memories` and `recency_days`. Both default to exactly what was hardcoded, so existing callers see no change.

Out-of-range values are **clamped, not refused** - the contract `top_k` settled on in `2d72fec`, where returning fewer results than asked for without saying so was the bug. A profile is a convenience view; failing one over an ambitious number helps nobody.

The maxima are not arbitrary: the memory budget is a graph query’s `LIMIT`, so it bounds real work, and a year is the widest window anyone has asked for.

Table-driven tests cover unset, negative, honoured, at-maximum and above-maximum for both.

Not in scope: the Python SDK and MCP client still call the endpoint without these parameters. They keep working on the defaults, and exposing them is a separate, smaller change once someone wants it.