### PR TITLE
Golden suite: an opt-in tier that can see the vector retriever

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-integration test-golden postgres-up lint clean docker-build proto-gen run kind-up kind-down deploy
+.PHONY: build test test-integration test-golden test-golden-quality postgres-up lint clean docker-build proto-gen run kind-up kind-down deploy
 
 # Compose refuses to start without credentials, so .env always holds a
 # generated password. The integration targets below have to use that same
@@ -40,6 +40,34 @@ test-integration: postgres-up
 test-golden: postgres-up
 	KORA_TEST_DATABASE_URL="$(TEST_DATABASE_URL)" \
 		go test ./test/golden/... -count=1 -race -v
+
+# The opt-in quality tier of the golden suite: the same corpus and cases, run
+# against a real embedding model, with its own higher floors.
+#
+# It answers what the gated suite cannot -- whether the vector retriever works
+# at all. Verified by deleting vector retrieval: the offline suite stays green,
+# this one fails on four assertions.
+#
+# Needs its own database. The embeddings column is created at the width first
+# seen, and nomic-embed-text is 768 where the default is 384, so pointing this
+# at the compose database would fail on dimension rather than on retrieval.
+#
+#   docker run -d --name kora-ollama -p 11435:11434 ollama/ollama
+#   docker exec kora-ollama ollama pull nomic-embed-text
+#   docker run -d --name kora-golden-pg -e POSTGRES_DB=kora -e POSTGRES_USER=kora \
+#     -e POSTGRES_PASSWORD=golden -p 55437:5432 <the postgres-age-vector image>
+GOLDEN_QUALITY_DSN ?= postgres://kora:golden@localhost:55437/kora?sslmode=disable
+GOLDEN_OLLAMA_URL ?= http://localhost:11435
+
+test-golden-quality:
+	@curl -sf $(GOLDEN_OLLAMA_URL)/api/tags >/dev/null || \
+		{ echo "no Ollama at $(GOLDEN_OLLAMA_URL); see the comment above this target"; exit 1; }
+	KORA_TEST_DATABASE_URL="$(GOLDEN_QUALITY_DSN)" \
+		KORA_TEST_EMBEDDING_PROVIDER=ollama \
+		KORA_TEST_EMBEDDING_MODEL=nomic-embed-text \
+		KORA_TEST_EMBEDDING_BASE_URL=$(GOLDEN_OLLAMA_URL) \
+		KORA_TEST_EMBEDDING_DIM=768 \
+		go test ./test/golden/... -count=1 -v
 
 postgres-up:
 	docker compose up -d postgres

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -429,6 +429,22 @@ KORA_TEST_DATABASE_URL="postgres://kora:$POSTGRES_PASSWORD@localhost:5432/kora?s
 A provider whose dimension differs from the default 384 needs its own database:
 the embedding column is created at the width first seen.
 
+`make test-golden-quality` runs exactly that, against Ollama and
+`nomic-embed-text`, and scores it against a **second, higher set of floors**.
+The two tiers measure different things:
+
+| tier | embedder | floors (overall) | runs |
+|---|---|---|---|
+| offline | bag-of-words | recall 0.90, MRR 0.83 | every PR |
+| online | nomic-embed-text | recall 0.92, MRR 0.86 | by hand, before a benchmark |
+
+The online tier exists because the offline one cannot see the vector retriever
+at all. Delete vector retrieval and the gated suite stays green -- with hashed
+bag-of-words there is no paraphrase this corpus can pose that vectors answer
+and full-text search does not. With a real embedder there is, and three
+paraphrase cases exist to be unreachable lexically. Verified by deleting it:
+the online tier fails on four assertions.
+
 When a change legitimately improves retrieval, raise the floors in the same
 commit, so the gain cannot be given back silently later. When a change lowers
 them, the commit message has to say which behaviour was traded away and why.

--- a/test/golden/golden.json
+++ b/test/golden/golden.json
@@ -70,6 +70,9 @@
     { "group": "paraphrase", "query": "How should I word a commit message?", "expect": "commit-style" },
     { "group": "paraphrase", "query": "Who is allowed to merge a pull request?", "expect": "review-rule" },
     { "group": "paraphrase", "query": "What time does the team meet each morning?", "expect": "standup" },
+    { "group": "paraphrase", "query": "Who signs off on my work before it ships?", "expect": "review-rule" },
+    { "group": "paraphrase", "query": "Is there a written record after something breaks for a while?", "expect": "postmortem-rule" },
+    { "group": "paraphrase", "query": "How often is disaster recovery rehearsed?", "expect": "backup-rule" },
 
     { "group": "subject", "query": "What does Priya own?", "expect": "priya-owns-billing" },
     { "group": "subject", "query": "What are Priya's editor preferences?", "expect": "priya-vim" },

--- a/test/golden/golden_test.go
+++ b/test/golden/golden_test.go
@@ -98,34 +98,78 @@ const embeddingDim = 384
 // retrieval, so the gain cannot be given back silently. Never lower one to
 // make a failing build pass without saying, in the commit message, which
 // behaviour was traded away and why.
-const (
-	minRecall = 0.90
-	minMRR    = 0.80
-)
+// Two tiers, because the suite measures two different things depending on what
+// it is pointed at.
+//
+// Offline is the gate: bag-of-words embeddings, no credentials, no network, run
+// on every PR. Its floors are what this engine can be held to without a model.
+//
+// Online is opt-in and not in the gate. It answers a question the offline tier
+// cannot: whether the vector retriever works at all. Deleting vector retrieval
+// leaves the offline suite green, because with hashed bag-of-words there is no
+// paraphrase this corpus can pose that vectors answer and full-text search does
+// not. With a real embedder there is, and three of the paraphrase cases exist
+// specifically to be unreachable lexically.
+type floors struct {
+	recall, mrr float64
+	groups      []groupFloor
+}
 
-// groups are the case groups, their floors, and the single place any of the
-// three names is written in Go. A case whose group is not one of these fails
-// the run rather than quietly scoring in the overall figure and nowhere else,
-// which is what a typo in golden.json used to buy.
-var groups = []struct {
+type groupFloor struct {
 	name        string
 	recall, mrr float64
-}{
-	// Queries sharing distinctive words with their answer.
-	{name: "lexical", recall: 1.00, mrr: 0.90},
-
-	// The paraphrase group is the weakest by construction: these queries share
-	// few words with their answers, so they lean on the embedder, and the
-	// offline bag-of-words embedder scores token overlap rather than meaning.
-	// Three of its ten cases miss entirely for that reason. This floor guards
-	// the fallback behaviour, not semantic understanding; with a real embedder
-	// configured it should be raised.
-	// Queries asking for the same thing in different words.
-	{name: "paraphrase", recall: 0.70, mrr: 0.55},
-
-	// Queries naming a person or service that several memories mention.
-	{name: "subject", recall: 1.00, mrr: 0.85},
 }
+
+// Measured with the bag-of-words embedder over 36 cases: overall 0.917 / 0.856,
+// lexical 1.000 / 0.958, paraphrase 0.769 / 0.679, subject 1.000 / 0.955.
+var offlineFloors = floors{
+	recall: 0.90, mrr: 0.83,
+	groups: []groupFloor{
+		{"lexical", 1.00, 0.90},
+		// Three of thirteen miss entirely: those queries share almost no words
+		// with their answers, and a hashed bag-of-words embedder scores token
+		// overlap rather than meaning. This floor guards the fallback, not
+		// semantic understanding.
+		{"paraphrase", 0.76, 0.62},
+		{"subject", 1.00, 0.90},
+	},
+}
+
+// Measured with Ollama and nomic-embed-text at 768 dimensions, same 36 cases:
+// overall 0.944 / 0.889, lexical 1.000 / 1.000, paraphrase 0.846 / 0.731,
+// subject 1.000 / 0.955. Three consecutive runs, identical.
+//
+// Tighter than offline on every axis, deliberately: a real embedder is
+// expected to do better, and a tier that accepted the offline numbers would
+// pass while the vector retriever did nothing.
+var onlineFloors = floors{
+	recall: 0.92, mrr: 0.86,
+	groups: []groupFloor{
+		{"lexical", 1.00, 0.95},
+		{"paraphrase", 0.84, 0.68},
+		{"subject", 1.00, 0.90},
+	},
+}
+
+// activeFloors picks the tier from what the suite was pointed at.
+func activeFloors() (floors, string) {
+	switch os.Getenv("KORA_TEST_EMBEDDING_PROVIDER") {
+	case "", "bag-of-words", "bow":
+		return offlineFloors, "offline"
+	default:
+		return onlineFloors, "online"
+	}
+}
+
+// groupNames is the single place the three names are written in Go. A case
+// whose group is not one of these fails the run rather than quietly scoring in
+// the overall figure and nowhere else, which is what a typo in golden.json used
+// to buy.
+//
+//	lexical    - shares distinctive words with its answer
+//	paraphrase - asks for the same thing in different words
+//	subject    - names a person or service several memories mention
+var groupNames = []string{"lexical", "paraphrase", "subject"}
 
 type goldenSet struct {
 	Corpus []struct {
@@ -158,13 +202,13 @@ func load(t *testing.T) goldenSet {
 
 	// A case in an unknown group would be scored in the overall figure and in
 	// no group floor, so a typo would quietly weaken the suite.
-	known := make(map[string]bool, len(groups))
-	for _, g := range groups {
-		known[g.name] = true
+	known := make(map[string]bool, len(groupNames))
+	for _, g := range groupNames {
+		known[g] = true
 	}
 	for _, c := range gs.Cases {
 		if !known[c.Group] {
-			t.Fatalf("case %q is in group %q, which has no floor in golden_test.go", c.Query, c.Group)
+			t.Fatalf("case %q is in group %q, which is not one of %v", c.Query, c.Group, groupNames)
 		}
 	}
 
@@ -325,10 +369,11 @@ func TestGoldenRetrieval(t *testing.T) {
 
 	report(t, outcomes)
 
-	overall := score(outcomes, "")
-	checkFloor(t, "overall", overall, minRecall, minMRR)
+	active, tier := activeFloors()
+	t.Logf("scoring against the %s floors", tier)
 
-	for _, g := range groups {
+	checkFloor(t, "overall", score(outcomes, ""), active.recall, active.mrr)
+	for _, g := range active.groups {
 		checkFloor(t, g.name, score(outcomes, g.name), g.recall, g.mrr)
 	}
 }
@@ -412,11 +457,7 @@ func report(t *testing.T, outcomes []outcome) {
 		b = append(b, (line + "\n")...)
 	}
 
-	names := make([]string, 0, len(groups)+1)
-	for _, g := range groups {
-		names = append(names, g.name)
-	}
-	for _, g := range append(names, "") {
+	for _, g := range append(append([]string{}, groupNames...), "") {
 		s := score(outcomes, g)
 		name := g
 		if name == "" {


### PR DESCRIPTION
Closes #67.

The gated suite cannot see the vector retriever. Deleting it leaves the suite green - with hashed bag-of-words embeddings there is no paraphrase this corpus can pose that vectors answer and full-text search does not, so **adding cases could not fix it**. The limitation is the embedder.

The same corpus and cases now run against a real model too, with their own floors.

| tier | embedder | overall floors | measured | runs |
|---|---|---|---|---|
| offline | bag-of-words | recall 0.90 / MRR 0.83 | 0.917 / 0.856 | every PR |
| online | nomic-embed-text (768d) | recall 0.92 / MRR 0.86 | **0.944 / 0.889** | by hand, before a benchmark |

Paraphrase is where they part: **0.769 offline against 0.846 online**. Three new cases were written for exactly that gap - `Who signs off on my work before it ships?` shares no content word with `Pull requests need one approval, and the author never merges their own work.`

## Verified the way the first version of this suite should have been

Delete vector retrieval:

- offline tier: **passes** (this is the gap)
- online tier: **fails on four assertions** - overall recall 0.917 < 0.920, overall MRR 0.843 < 0.860, paraphrase recall 0.769 < 0.840, paraphrase MRR 0.679 < 0.680

Three consecutive online runs produced identical numbers, so the floors are set one lost case below measured rather than padded.

`make test-golden-quality` runs it. It needs its own database, because the embeddings column is created at the width first seen and nomic-embed-text is 768 where the default is 384 - pointing it at the compose database fails on dimension rather than on retrieval. The target says so and checks Ollama is reachable before running.

CI is unchanged: still offline, still no credentials.