### PR TITLE
Say which context0 names survived the rename, and why

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,21 @@ The script renames both (catalog-only, so the cost does not scale with database
 size), reaps any privileged helper role left by an interrupted run, and
 verifies the graph is still readable afterwards. It is idempotent.
 
-The AGE graph and its schema keep the name `context0` under either option -
-renaming those is a data migration with no functional benefit. See `GraphName`
-in `internal/graph/age.go`.
+### What still says context0, and why
+
+Three names survived the rename on purpose. Each is data-bearing or
+credential-bearing, so renaming it would cost an existing deployment something
+real in exchange for consistency:
+
+| Name | Where | Why it stays |
+|---|---|---|
+| The AGE graph and its schema | `GraphName` in `internal/graph/age.go` | It is the Postgres schema holding every deployment's data. Renaming it is a data migration with no functional benefit, and the SQL in `docs/research/` refers to it. |
+| The `ctx0_` API key prefix | `KeyPrefix` in `internal/auth/keys.go` | It is in every key ever issued. Changing it invalidates all of them to fix an aesthetic problem. |
+| The Cloudflare Pages project | `.github/workflows/site.yaml` | Renaming it changes the deployment target of the docs site. |
+
+Everything else - the module, the binaries, the chart, the environment
+variables, the repository - is Kora. If you see `context0` anywhere other than
+the three rows above, it is a leftover and worth an issue.
 
 ### Prerequisites
 


### PR DESCRIPTION
Closes #61.

The repository, module, binaries, chart and environment variables are all Kora already. Three `context0` names survived on purpose, and each had a comment explaining itself *at its own site* - which is the wrong place for someone who has just noticed the inconsistency and is deciding whether it is a leftover.

| Name | Why it stays |
|---|---|
| The AGE graph and schema | It is the Postgres schema holding every deployment’s data. Renaming it is a data migration with no functional benefit. |
| The `ctx0_` key prefix | It is in every key ever issued. Changing it invalidates all of them to fix an aesthetic problem. |
| The Cloudflare Pages project | Renaming it changes the deployment target of the docs site. |

Stated once, next to the upgrade instructions, with the rule that follows: **`context0` anywhere else is a leftover and worth an issue.**

The local working directory is the last piece and is not a repository change; I am renaming it separately.