### PR TITLE
Check the quality profile renders, and expose profile sizing in MCP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,30 @@ jobs:
             --set postgres.existingSecret=my-pg \
             --set auth.existingSecret=my-keys > /dev/null
 
+          # The quality profile is a supported install path, so it has to keep
+          # rendering. It was added with only a hand-run `helm template`
+          # behind it, which is exactly how a values file rots: nothing
+          # references it until someone tries it.
+          helm template kora ./charts/kora -f ./charts/kora/values-quality.yaml \
+            --set postgres.password=ci-render-only \
+            --set auth.apiKeys=ctx0_ci_render_only > /tmp/quality.yaml
+
+          # Rendering is not enough. The point of that file is that both
+          # backends stop being the zero-dependency defaults, and a typo in a
+          # values key renders happily while changing nothing.
+          for setting in \
+            'KORA_EMBEDDING_PROVIDER' 'KORA_EMBEDDING_MODEL' 'KORA_EMBEDDING_DIM' \
+            'KORA_EXTRACTION_PROVIDER' 'KORA_EXTRACTION_MODEL' 'KORA_EXTRACTION_BASE_URL'; do
+            grep -q "$setting" /tmp/quality.yaml || {
+              echo "::error::the quality profile renders without $setting; a values key no longer matches the template"
+              exit 1
+            }
+          done
+          grep -q 'value: "bag-of-words"' /tmp/quality.yaml && {
+            echo "::error::the quality profile still selects the default embedder"
+            exit 1
+          }
+
           # And the guard itself must hold: a credential-less install has to
           # fail loudly rather than quietly shipping an empty password.
           if helm template kora ./charts/kora > /dev/null 2>&1; then

--- a/mcp-server/kora_mcp/client.py
+++ b/mcp-server/kora_mcp/client.py
@@ -129,11 +129,23 @@ class KoraClient:
         self,
         project_id: str,
         query: str = "",
+        max_memories: int = 0,
+        recency_days: int = 0,
     ) -> dict[str, Any]:
-        """GET /v1/profiles/{project_id} — get user/project profile."""
+        """GET /v1/profiles/{project_id} — get user/project profile.
+
+        max_memories and recency_days are optional. Zero means the engine's
+        documented defaults (200 memories, a 7-day window for what counts as
+        current); the engine clamps rather than refusing values above its
+        maximum, so an ambitious number is served at the maximum.
+        """
         params: dict[str, Any] = {}
         if query:
             params["query"] = query
+        if max_memories:
+            params["maxMemories"] = max_memories
+        if recency_days:
+            params["recencyDays"] = recency_days
         r = await self._client.get(f"/v1/profiles/{project_id}", params=params)
         r.raise_for_status()
         return r.json()

--- a/mcp-server/kora_mcp/server.py
+++ b/mcp-server/kora_mcp/server.py
@@ -157,20 +157,28 @@ async def memory_extract(
 
 @mcp.tool(
     description="Get an aggregated profile for a user or project, combining stable facts "
-    "(preferences, expertise, known information) with recent context (events from the "
-    "last 7 days). Use this at the start of a conversation to understand who you're "
-    "talking to.",
+    "(preferences, expertise, known information) with recent context (recent events, "
+    "7 days by default). Use this at the start of a conversation to understand who "
+    "you're talking to. Widen recency_days when the work is episodic and slower moving.",
     tags={"memory", "profile"},
 )
 async def memory_profile(
     project_id: Annotated[str, Field(description="Project/user to get profile for")] = "",
     query: Annotated[str, Field(description="Optional query to filter profile relevance")] = "",
+    max_memories: Annotated[
+        int, Field(description="How many memories to build the profile from (0 = engine default of 200)")
+    ] = 0,
+    recency_days: Annotated[
+        int, Field(description="How recent a memory must be to count as current (0 = engine default of 7)")
+    ] = 0,
 ) -> str:
     """Get aggregated user/project profile."""
     client = _get_client()
     pid = project_id or DEFAULT_PROJECT
 
-    result = await client.get_profile(project_id=pid, query=query)
+    result = await client.get_profile(
+        project_id=pid, query=query, max_memories=max_memories, recency_days=recency_days
+    )
 
     static = result.get("staticProfile", [])
     dynamic = result.get("dynamicProfile", [])

--- a/mcp-server/tests/test_e2e.py
+++ b/mcp-server/tests/test_e2e.py
@@ -124,6 +124,23 @@ async def run():
     if p is not None:
         check("get_profile() returns an object", isinstance(p, dict), f"got {type(p).__name__}")
 
+    # The sizing parameters are optional and clamped rather than refused, so an
+    # ambitious value must come back as a profile rather than an error. A
+    # parameter the gateway does not recognise would surface here as a 400.
+    sized = await attempt(
+        "get_profile() accepts a size and a recency window",
+        c.get_profile(project, max_memories=5, recency_days=90),
+    )
+    if sized is not None:
+        check("sized profile returns an object", isinstance(sized, dict), f"got {type(sized).__name__}")
+
+    clamped = await attempt(
+        "get_profile() clamps an out-of-range size instead of failing",
+        c.get_profile(project, max_memories=10_000_000, recency_days=100_000),
+    )
+    if clamped is not None:
+        check("clamped profile returns an object", isinstance(clamped, dict), f"got {type(clamped).__name__}")
+
     section("5. Connect and graph")
     s2 = await attempt(
         "a second store for the edge",


### PR DESCRIPTION
Two things shipped this week that nothing exercised.

**`values-quality.yaml`** (#59) was added with a hand-run `helm template` behind it. That is how a values file rots: nothing references it until someone tries it and finds a key that no longer matches the template. CI now renders it *and asserts the settings it exists to change are present* - rendering alone passes with a typo’d values key, because Helm renders nothing happily.

**`GetProfile`** (#63) gained `max_memories` and `recency_days` while the MCP server kept calling it with neither, so the tool agents actually use could not widen a profile’s window. Both are now exposed, with the tool description saying when to reach for the wider one.

The E2E probe checks the interesting case rather than the happy one: an out-of-range value must come back as a **profile rather than an error**, since the engine clamps. That also catches a field name the gateway does not recognise, which is the failure mode a JSON parameter rename produces.