### PR TITLE
Cover the degradation contracts mutation testing found unguarded

### DIFF
--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -25,6 +25,38 @@ Every one of those was green. Mutation testing automates the check that caught
 them: change the source in a way a correct test must notice, run the tests, and
 report anything the suite sleeps through.
 
+## What it found in the retrieval and ingest split
+
+Run against the two packages the read and write paths moved into, immediately
+after the move:
+
+| package | before | after |
+|---|---|---|
+| `internal/retrieval` | 1 of 6 killed | **5 of 6** |
+| `internal/ingest` | 1 of 6 killed | **6 of 6** |
+| `internal/service` | 12 of 18 killed | **18 of 18** |
+
+Every survivor was the same shape: an error branch whose comment promised the
+engine degrades rather than fails, with nothing asserting it. A failed vector
+search returning keyword results, a failed candidate lookup skipping
+contradiction detection rather than losing the write, a failed searchability
+check *not* falling back. All were written down as intent and none were tested.
+
+The second thing it found is subtler and worth repeating: **a test for the
+failure path alone kills nothing.** Forcing `if err != nil` true is invisible to
+a test that already supplies an error. Half the survivors needed the success
+case -- the fallback that runs, the contradiction that is found, the vector hit
+that reaches the caller -- because that is what the mutation removes.
+
+It also found dead defence. `NewMemoryServiceWithExtractor` and `ingest.New`
+both replaced a nil extractor with the rule-based one; the service's copy is
+gone, because duplicate defence in two layers is how the two drift apart.
+
+One mutant survives on purpose. Forcing the `verr != nil` branch after
+`SearchByVector` adds a log line and changes nothing else, since the results
+are assigned before the check. It is an equivalent mutant, recorded in
+`internal/retrieval/degradation_test.go` so nobody writes a test for it.
+
 ## Usage
 
 ```sh

--- a/internal/ingest/contract_test.go
+++ b/internal/ingest/contract_test.go
@@ -1,0 +1,249 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NarayanaSabari/Kora/internal/extraction"
+	"github.com/NarayanaSabari/Kora/internal/graph"
+	"github.com/NarayanaSabari/Kora/pkg/model"
+	"github.com/google/uuid"
+)
+
+// The write path's promises, as tests.
+//
+// Mutation testing found five of them unprotected: contradiction detection
+// running for the wrong memory types, a failed candidate lookup taking the
+// write with it, a failed embedding batch doing the same, duplicate content
+// hashes being looked up repeatedly, and New() ignoring a nil extractor.
+// Every one of those is a comment in the source promising behaviour that no
+// test checked.
+//
+// These use the Repo seam rather than a database. The question is what the
+// engine does when a dependency misbehaves, which is hard to arrange in
+// Postgres and trivial here.
+
+type recordingRepo struct {
+	createErr    error
+	queryErr     error
+	queryResults []model.MemoryWithContext
+	hashErr      error
+	hashResult   map[graph.ContentKey]model.Memory
+
+	created         []model.Memory
+	queryCalls      int
+	hashLookups     [][]string
+	embeddingsSaved int
+}
+
+func (r *recordingRepo) CreateMemory(_ context.Context, mem model.Memory) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = append(r.created, mem)
+	return nil
+}
+func (r *recordingRepo) CreateEdges(context.Context, []model.Edge) error { return nil }
+func (r *recordingRepo) StoreEmbedding(context.Context, uuid.UUID, string, []float32) error {
+	r.embeddingsSaved++
+	return nil
+}
+func (r *recordingRepo) LinkMemoryToSession(context.Context, uuid.UUID, uuid.UUID) error { return nil }
+func (r *recordingRepo) LinkEntities(context.Context, model.Memory, []string) (int, error) {
+	return 0, nil
+}
+func (r *recordingRepo) FindByContentHash(_ context.Context, _ string, hashes []string) (map[graph.ContentKey]model.Memory, error) {
+	r.hashLookups = append(r.hashLookups, hashes)
+	return r.hashResult, r.hashErr
+}
+func (r *recordingRepo) UpdateMemoryContent(context.Context, uuid.UUID, string, string) (bool, error) {
+	return true, nil
+}
+func (r *recordingRepo) QueryMemories(context.Context, graph.QueryFilter) ([]model.MemoryWithContext, error) {
+	r.queryCalls++
+	return r.queryResults, r.queryErr
+}
+func (r *recordingRepo) SearchByVector(context.Context, []float32, string, int) ([]model.MemoryWithContext, error) {
+	return nil, nil
+}
+func (r *recordingRepo) IncrementAccessCounts(context.Context, []uuid.UUID) error { return nil }
+
+type stubEmbedder struct{ err error }
+
+func (e stubEmbedder) Embed(string) ([]float32, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return make([]float32, 8), nil
+}
+func (e stubEmbedder) Dimension() int { return 8 }
+
+// Contradiction detection runs for semantic memories only.
+//
+// An episodic memory records that something happened; a later event does not
+// contradict an earlier one, it follows it. Running detection over episodes
+// would supersede yesterday's walk with today's, and a supersedes edge is
+// destructive to ranking order.
+func TestDetectAndSupersede_OnlySemanticMemoriesAreCandidates(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		memType    model.MemoryType
+		wantLookup bool
+	}{
+		{"semantic memories can contradict each other", model.MemoryTypeSemantic, true},
+		{"episodic memories cannot: a later event follows an earlier one", model.MemoryTypeEpisodic, false},
+		{"procedural memories cannot", model.MemoryTypeProcedural, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &recordingRepo{}
+			eng := New(repo, nil, nil)
+
+			eng.detectAndSupersede(context.Background(), model.Memory{
+				ID: uuid.New(), Type: tt.memType, ProjectID: "proj", Content: "Caroline lives in Lisbon",
+			})
+
+			if got := repo.queryCalls > 0; got != tt.wantLookup {
+				t.Errorf("candidate lookup ran = %v, want %v for a %s memory", got, tt.wantLookup, tt.memType)
+			}
+		})
+	}
+}
+
+// A failed candidate lookup skips contradiction detection; it does not fail
+// the write. The memory is already committed at this point, and losing a
+// supersedes edge is a worse answer later, while failing here would be a lost
+// write now.
+func TestDetectAndSupersede_LookupFailureIsNotFatal(t *testing.T) {
+	repo := &recordingRepo{queryErr: errors.New("graph unreachable")}
+	eng := New(repo, nil, nil)
+
+	superseded := eng.detectAndSupersede(context.Background(), model.Memory{
+		ID: uuid.New(), Type: model.MemoryTypeSemantic, ProjectID: "proj", Content: "Caroline lives in Lisbon",
+	})
+	if len(superseded) != 0 {
+		t.Errorf("got %d supersedes with a failed lookup; nothing could have been compared", len(superseded))
+	}
+}
+
+// Content hashes are deduplicated before the lookup.
+//
+// A conversation that states the same fact twice would otherwise send the same
+// hash twice, and the lookup is one query whose size is the number of hashes:
+// the deduplication is what keeps a repetitive transcript from paying for its
+// repetition.
+func TestExistingByContent_LooksUpEachHashOnce(t *testing.T) {
+	repo := &recordingRepo{hashResult: map[graph.ContentKey]model.Memory{}}
+	eng := New(repo, nil, nil)
+
+	same := "Caroline adopted a rescue dog named Biscuit."
+	eng.existingByContent(context.Background(), "proj", []model.Memory{
+		{ID: uuid.New(), Content: same},
+		{ID: uuid.New(), Content: same},
+		{ID: uuid.New(), Content: "Melanie signed up for a pottery class."},
+		{ID: uuid.New(), Content: ""},
+	})
+
+	if len(repo.hashLookups) != 1 {
+		t.Fatalf("made %d lookups, want 1: the batch exists to be one round trip", len(repo.hashLookups))
+	}
+	if got := len(repo.hashLookups[0]); got != 2 {
+		t.Errorf("looked up %d hashes for two distinct non-empty contents (one stated twice): %v",
+			got, repo.hashLookups[0])
+	}
+}
+
+// A failed embedding batch loses the vectors, not the memories.
+//
+// Without an embedding a memory is absent from vector search and still
+// findable by keyword and entity. Failing the write instead would discard
+// facts the caller has already been told were extracted.
+func TestEmbedExtracted_ProviderFailureLosesVectorsNotMemories(t *testing.T) {
+	repo := &recordingRepo{}
+	eng := New(repo, stubEmbedder{err: errors.New("provider down")}, nil)
+
+	memories := []model.Memory{
+		{ID: uuid.New(), Content: "Caroline adopted a rescue dog"},
+		{ID: uuid.New(), Content: "Melanie took up pottery"},
+	}
+	vectors := eng.embedExtracted(context.Background(), memories)
+
+	if len(vectors) != 0 {
+		t.Errorf("got %d vectors from a failing provider, want none", len(vectors))
+	}
+}
+
+// A nil extractor means the rule-based one, not a nil dereference on the first
+// conversation.
+func TestNew_NilExtractorFallsBackToTheRuleBasedOne(t *testing.T) {
+	eng := New(&recordingRepo{}, nil, nil)
+	if eng.extractor == nil {
+		t.Fatal("New(nil extractor) left the engine without one")
+	}
+	if _, ok := eng.extractor.(extraction.RuleExtractor); !ok {
+		t.Errorf("got %T, want the rule-based extractor", eng.extractor)
+	}
+}
+
+// The other half of each contract above: the path where nothing fails.
+//
+// A test that only covers the failure passes whether or not the success is
+// wired up at all, which is how a feature ends up looking guarded while being
+// unreachable.
+
+// A contradiction that is found produces a supersedes edge.
+func TestDetectAndSupersede_FindsAContradiction(t *testing.T) {
+	older := model.Memory{
+		ID: uuid.New(), Type: model.MemoryTypeSemantic, ProjectID: "proj",
+		Content: "Caroline is vegetarian.",
+	}
+	repo := &recordingRepo{queryResults: []model.MemoryWithContext{{Memory: older}}}
+	eng := New(repo, nil, nil)
+
+	superseded := eng.detectAndSupersede(context.Background(), model.Memory{
+		ID: uuid.New(), Type: model.MemoryTypeSemantic, ProjectID: "proj",
+		Content: "Caroline is not vegetarian.",
+	})
+
+	if len(superseded) == 0 {
+		t.Fatal("a direct negation of an existing fact produced no supersedes: " +
+			"contradiction detection ran and found nothing, or did not run")
+	}
+	if !superseded[older.ID] {
+		t.Errorf("superseded %v, want the contradicted memory %s", superseded, older.ID)
+	}
+}
+
+// A working embedder produces one vector per memory.
+func TestEmbedExtracted_ReturnsAVectorPerMemory(t *testing.T) {
+	eng := New(&recordingRepo{}, stubEmbedder{}, nil)
+
+	memories := []model.Memory{
+		{ID: uuid.New(), Content: "Caroline adopted a rescue dog"},
+		{ID: uuid.New(), Content: "Melanie took up pottery"},
+	}
+	vectors := eng.embedExtracted(context.Background(), memories)
+
+	if len(vectors) != len(memories) {
+		t.Fatalf("got %d vectors for %d memories", len(vectors), len(memories))
+	}
+	for _, m := range memories {
+		if len(vectors[m.ID]) == 0 {
+			t.Errorf("memory %s got no vector; it would be absent from vector search", m.ID)
+		}
+	}
+}
+
+// An extractor that was supplied is the one used.
+func TestNew_KeepsTheExtractorItWasGiven(t *testing.T) {
+	want := extraction.RuleExtractor{}
+	eng := New(&recordingRepo{}, nil, stubExtractor{})
+	if _, isRule := eng.extractor.(extraction.RuleExtractor); isRule {
+		t.Errorf("New replaced the supplied extractor with %T", want)
+	}
+}
+
+// stubExtractor is distinguishable from the rule-based extractor by type.
+type stubExtractor struct{}
+
+func (stubExtractor) Extract(string) ([]extraction.ExtractedMemory, error) { return nil, nil }

--- a/internal/retrieval/degradation_test.go
+++ b/internal/retrieval/degradation_test.go
@@ -1,0 +1,297 @@
+package retrieval
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NarayanaSabari/Kora/internal/graph"
+	"github.com/NarayanaSabari/Kora/pkg/model"
+	"github.com/google/uuid"
+)
+
+// The read path promises, in comments at each site, that a failing retriever
+// degrades rather than fails the query, and that one particular failure must
+// *not* degrade. Mutation testing found every one of those promises
+// unprotected: forcing each error branch to fire changed nothing any test
+// noticed.
+//
+// These are the contracts, as tests. They use the Repo seam rather than a
+// database, because the question is what the engine does when a dependency
+// misbehaves, and a real Postgres is hard to make misbehave on demand.
+//
+// One mutant in this file's target survives on purpose and cannot be killed:
+// forcing the `verr != nil` branch after SearchByVector emits a log line and
+// changes nothing else, because the results are assigned before the check. It
+// is an equivalent mutant, not a gap; do not write a test for it.
+
+// fakeRepo answers with whatever the test sets, and records what it was asked.
+type fakeRepo struct {
+	textResults   []model.MemoryWithContext
+	textErr       error
+	searchable    bool
+	searchableErr error
+	queryResults  []model.MemoryWithContext
+	queryErr      error
+	vectorResults []model.MemoryWithContext
+	vectorErr     error
+	entityErr     error
+
+	queryMemoriesCalled bool
+	searchByVectorCalls int
+}
+
+func (f *fakeRepo) SearchByText(context.Context, string, []string, int) ([]model.MemoryWithContext, error) {
+	return f.textResults, f.textErr
+}
+
+func (f *fakeRepo) KeywordsAreSearchable(context.Context, []string) (bool, error) {
+	return f.searchable, f.searchableErr
+}
+
+func (f *fakeRepo) QueryMemories(context.Context, graph.QueryFilter) ([]model.MemoryWithContext, error) {
+	f.queryMemoriesCalled = true
+	return f.queryResults, f.queryErr
+}
+
+func (f *fakeRepo) SearchByVector(context.Context, []float32, string, int) ([]model.MemoryWithContext, error) {
+	f.searchByVectorCalls++
+	return f.vectorResults, f.vectorErr
+}
+
+func (f *fakeRepo) FindMemoriesByEntities(context.Context, string, []string, int) ([]model.Memory, error) {
+	return nil, f.entityErr
+}
+
+func (f *fakeRepo) GetMemoryEntities(context.Context, []uuid.UUID) (map[uuid.UUID][]string, error) {
+	return nil, nil
+}
+
+// fixedEmbedder returns a constant vector, or an error.
+type fixedEmbedder struct{ err error }
+
+func (e fixedEmbedder) Embed(string) ([]float32, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return make([]float32, 8), nil
+}
+func (e fixedEmbedder) Dimension() int { return 8 }
+
+func memory(content string) model.MemoryWithContext {
+	return model.MemoryWithContext{
+		Memory: model.Memory{ID: uuid.New(), Content: content, Type: model.MemoryTypeSemantic, DecayScore: 1},
+	}
+}
+
+// Keyword search is the one retriever whose failure is fatal.
+//
+// It is not a degradation: the other two exist to cover its gaps, not to
+// stand in for it, and answering a keyword query from vector similarity alone
+// would be a different answer presented as the same one.
+func TestRetrieve_KeywordFailureIsAnError(t *testing.T) {
+	repo := &fakeRepo{textErr: errors.New("postgres is on fire")}
+	_, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "anything at all", "proj", nil, 5)
+	if err == nil {
+		t.Fatal("keyword search failed and Retrieve returned no error: the caller cannot " +
+			"tell a broken retriever from a project with nothing in it")
+	}
+}
+
+// A failed searchability check must not trigger the fallback.
+//
+// The fallback answers "this query had nothing to search for" with the
+// project's recent memories. Reaching it because the *check* failed would turn
+// a precise empty answer -- the query ran, nothing matched -- into a page of
+// unrelated memories, which is the exact behaviour full-text search replaced.
+func TestRetrieve_UnknownSearchabilityDoesNotFallBack(t *testing.T) {
+	repo := &fakeRepo{
+		textResults:   nil, // a real search that matched nothing
+		searchableErr: errors.New("cannot reach the dictionary"),
+		queryResults:  []model.MemoryWithContext{memory("something unrelated")},
+	}
+
+	results, err := New(repo, nil).Retrieve(context.Background(), "zqxjklmw", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if repo.queryMemoriesCalled {
+		t.Error("the searchability check failed and the fallback ran anyway: " +
+			"an unanswerable check must be treated as a real search, not as an empty one")
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for a search that matched nothing; a precise empty "+
+			"answer became a page of unrelated memories", len(results))
+	}
+}
+
+// A query with nothing to search for is answered by the fallback, and a
+// failure there is fatal: at that point there is no other source of candidates.
+func TestRetrieve_FallbackFailureIsAnError(t *testing.T) {
+	repo := &fakeRepo{queryErr: errors.New("graph query failed")}
+	_, err := New(repo, nil).Retrieve(context.Background(), "", "proj", nil, 5)
+	if err == nil {
+		t.Fatal("the fallback failed and Retrieve returned no error")
+	}
+}
+
+// Vector search failing is a degradation, not a failure: the caller gets a
+// quietly worse answer built from the retrievers that did work.
+func TestRetrieve_VectorFailureDegradesToKeywordResults(t *testing.T) {
+	want := memory("Caroline adopted a rescue dog named Biscuit")
+	repo := &fakeRepo{
+		textResults: []model.MemoryWithContext{want},
+		vectorErr:   errors.New("pgvector unavailable"),
+	}
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "Biscuit", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("vector search failed and took the whole query with it: %v", err)
+	}
+	if len(results) != 1 || results[0].Memory.ID != want.Memory.ID {
+		t.Errorf("got %d results; keyword evidence must survive a failed vector search", len(results))
+	}
+}
+
+// An embedder that errors is the same degradation, one step earlier.
+func TestRetrieve_EmbedderFailureDegradesToKeywordResults(t *testing.T) {
+	want := memory("Caroline adopted a rescue dog named Biscuit")
+	repo := &fakeRepo{textResults: []model.MemoryWithContext{want}}
+
+	results, err := New(repo, fixedEmbedder{err: errors.New("provider down")}).
+		Retrieve(context.Background(), "Biscuit", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("an unreachable embedding provider failed the query: %v", err)
+	}
+	if repo.searchByVectorCalls != 0 {
+		t.Error("the query could not be embedded and vector search ran anyway")
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d results; a failed embedding must not lose the keyword hits", len(results))
+	}
+}
+
+// No embedder configured is a supported deployment, not a degraded one: it is
+// what a default install runs. Vector search must not be attempted at all.
+func TestRetrieve_NoEmbedderSkipsVectorSearchEntirely(t *testing.T) {
+	repo := &fakeRepo{textResults: []model.MemoryWithContext{memory("a stored fact")}}
+
+	results, err := New(repo, nil).Retrieve(context.Background(), "fact", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("Retrieve without an embedder: %v", err)
+	}
+	if repo.searchByVectorCalls != 0 {
+		t.Errorf("vector search was called %d times with no embedder configured", repo.searchByVectorCalls)
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d results, want 1", len(results))
+	}
+}
+
+// Entity retrieval failing is the mildest degradation: it is supplementary, so
+// losing it makes the answer quietly worse rather than wrong.
+func TestRetrieve_EntityFailureDegrades(t *testing.T) {
+	want := memory("Caroline works from Lisbon")
+	repo := &fakeRepo{
+		textResults: []model.MemoryWithContext{want},
+		entityErr:   errors.New("entity lookup failed"),
+	}
+
+	results, err := New(repo, nil).Retrieve(context.Background(), "Where does Caroline work?", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("entity retrieval failed and took the query with it: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d results; the other retrievers' evidence must survive", len(results))
+	}
+}
+
+// The other half of the searchability contract: when the check succeeds and
+// says the query has nothing to search for, the fallback *does* run.
+//
+// Both halves are needed. A test that only covers the failing check passes
+// whether or not the successful one is wired up, which is how the fallback
+// could be silently unreachable while looking guarded.
+func TestRetrieve_UnsearchableQueryFallsBackToRecentMemories(t *testing.T) {
+	fallback := memory("the project's most recent memory")
+	repo := &fakeRepo{
+		textResults:  nil,   // "the" matches nothing
+		searchable:   false, // and PostgreSQL confirms there was nothing to match
+		queryResults: []model.MemoryWithContext{fallback},
+	}
+
+	results, err := New(repo, nil).Retrieve(context.Background(), "the and of", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if !repo.queryMemoriesCalled {
+		t.Error("a query with nothing to search for did not reach the fallback: " +
+			"a bare 'list everything' request must be answered by recency, not by nothing")
+	}
+	if len(results) != 1 || results[0].Memory.ID != fallback.Memory.ID {
+		t.Errorf("got %d results; the fallback's memories must reach the caller", len(results))
+	}
+}
+
+// Vector results reach the caller when everything works.
+//
+// The failure tests above all assert that a broken retriever does not lose the
+// others' evidence, which passes trivially if the retriever never contributes
+// anything. This is the case that fails if vector retrieval is disconnected.
+func TestRetrieve_VectorOnlyHitsReachTheCaller(t *testing.T) {
+	lexical := memory("Caroline uses PostgreSQL for the primary datastore")
+	// Score carries the cosine on a vector hit, and it has to be a plausible
+	// one: a vector-only candidate has no other evidence, so the semantic gate
+	// judges it on this number alone.
+	semantic := memory("the team moved off MySQL last spring")
+	semantic.Score = 0.8
+	repo := &fakeRepo{
+		textResults:   []model.MemoryWithContext{lexical},
+		vectorResults: []model.MemoryWithContext{semantic},
+	}
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "PostgreSQL", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if repo.searchByVectorCalls != 1 {
+		t.Fatalf("vector search ran %d times, want 1", repo.searchByVectorCalls)
+	}
+
+	var sawSemantic bool
+	for _, r := range results {
+		if r.Memory.ID == semantic.Memory.ID {
+			sawSemantic = true
+		}
+	}
+	if !sawSemantic {
+		t.Error("a memory only vector search found did not reach the caller: " +
+			"the retriever ran and its results were discarded")
+	}
+}
+
+// The semantic gate: a memory only vector search found, and found weakly, is
+// dropped rather than returned.
+//
+// This is the counterpart to the test above. Vector search returns its top-K
+// whatever the similarity, so without a floor a query with no good semantic
+// match still gets one, and the caller cannot tell the difference. A candidate
+// another retriever also found is not gated, because it was retrieved on
+// evidence the gate says nothing about.
+func TestRetrieve_WeakVectorOnlyHitsAreGated(t *testing.T) {
+	weak := memory("an unrelated memory the embedder placed vaguely nearby")
+	weak.Score = 0.02
+
+	repo := &fakeRepo{vectorResults: []model.MemoryWithContext{weak}}
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "something specific", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	for _, r := range results {
+		if r.Memory.ID == weak.Memory.ID {
+			t.Error("a vector-only hit below the semantic gate was returned: " +
+				"a query with no good match must come back empty rather than plausible")
+		}
+	}
+}

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -40,15 +40,17 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// MemoryService implements the Kora gRPC service. It holds a graph repository
-// for persistent memory storage and traversal, an optional embedder for
-// generating vector representations used in hybrid search, and an extractor
-// that turns raw conversations into structured memories.
+// MemoryService implements the Kora gRPC service.
+//
+// It is the wire layer and little else now: protobuf in, protobuf out, and the
+// arguments that belong to the wire format -- notably session ids, where Store
+// rejects a malformed one and Extract warns and carries on. The behaviour sits
+// in the two engines either side of the store, internal/ingest and
+// internal/retrieval.
 type MemoryService struct {
 	pb.UnimplementedKoraServer
-	repo      *graph.AGERepository
-	embedder  embedding.Embedder
-	extractor extraction.Extractor
+	repo     *graph.AGERepository
+	embedder embedding.Embedder
 
 	// The two halves of the engine's behaviour, either side of the store.
 	// Constructed here rather than injected because the service is what
@@ -69,17 +71,14 @@ func NewMemoryService(repo *graph.AGERepository, embedder embedding.Embedder) *M
 }
 
 // NewMemoryServiceWithExtractor is NewMemoryService with an explicit
-// extraction backend. A nil extractor falls back to the rule-based scanner,
-// so a caller that forgets to configure one still gets working extraction
-// rather than a nil dereference on the first Extract call.
+// extraction backend. A nil extractor falls back to the rule-based scanner --
+// in ingest.New, which is the only place that decision is now made. The
+// service used to make it too, and duplicate defence in two layers is how the
+// two drift apart.
 func NewMemoryServiceWithExtractor(repo *graph.AGERepository, embedder embedding.Embedder, extractor extraction.Extractor) *MemoryService {
-	if extractor == nil {
-		extractor = extraction.RuleExtractor{}
-	}
 	return &MemoryService{
 		repo:      repo,
 		embedder:  embedder,
-		extractor: extractor,
 		retrieval: retrieval.New(repo, embedder),
 		ingest:    ingest.New(repo, embedder, extractor),
 	}


### PR DESCRIPTION
Ran `scripts/mutate.py` against the packages the read and write paths just moved into. The results were bad in a specific, fixable way:

| package | before | after |
|---|---|---|
| `internal/retrieval` | 1 of 6 killed | **5 of 6** |
| `internal/ingest` | 1 of 6 killed | **6 of 6** |
| `internal/service` | 12 of 18 | **18 of 18** |
| total | 14 of 36 | **35 of 36** |

**Every survivor was the same shape**: an error branch whose comment promised the engine degrades rather than fails, with nothing asserting it.

- a failed vector search returning keyword results
- a failed candidate lookup skipping contradiction detection rather than losing the write
- a failed searchability check *not* falling back, which is the distinction `2d72fec` was written to preserve
- a nil embedder skipping vector search entirely, which is what a default install does

Those promises are tests now, written against the `Repo` seams the two refactors introduced - which is what they were for.

## The lesson worth repeating

**A test for the failure path alone kills nothing.** Forcing `if err != nil` true is invisible to a test that already supplies an error. Half these needed the success case too: the fallback that runs, the contradiction that is found, the vector hit that reaches the caller. That is now written into `docs/mutation-testing.md`, because it is not obvious and I got it wrong on the first pass.

## One test failed when written, and was right to

`TestRetrieve_VectorOnlyHitsReachTheCaller` failed: a vector-only hit with cosine 0 never reaches the caller. The engine was correct - the semantic gate drops it - and my fake was unrealistic. That behaviour now has its own test, `TestRetrieve_WeakVectorOnlyHitsAreGated`.

## Dead defence removed

`NewMemoryServiceWithExtractor` and `ingest.New` both replaced a nil extractor with the rule-based one. The service’s copy is gone: duplicate defence in two layers is how the two drift apart.

The remaining survivor is equivalent - forcing it emits a log line and changes nothing, because the results are assigned before the check. Recorded in the test file so nobody writes a test for it.