### PR TITLE
Close the mutation gaps across graph, extraction, ranking and model

### DIFF
--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -57,6 +57,38 @@ One mutant survives on purpose. Forcing the `verr != nil` branch after
 are assigned before the check. It is an equivalent mutant, recorded in
 `internal/retrieval/degradation_test.go` so nobody writes a test for it.
 
+## The second sweep: graph, extraction, ranking, model
+
+| package | before | after |
+|---|---|---|
+| `internal/extraction` | 24 of 30 | **30 of 30** |
+| `internal/graph` | 23 of 24 | **24 of 24** |
+| `internal/ranking` | 9 of 15 | 12 of 15 |
+| `pkg/model` | 5 of 6 | **6 of 6** |
+
+Three kinds of finding, and only one of them is "write a test".
+
+**Real gaps.** A content hash that changed when punctuation sat between two
+words, so the same fact stated twice would be stored twice -- invisible to the
+existing tests, because a string of pure punctuation hashes to the empty string
+either way. An entity named twice in one memory producing two nodes. A ranking
+comparator whose score and identity branches could be swapped without any test
+noticing, because the existing one built its memories with random UUIDs and
+passed on the luck of the draw. And `LinkEntities` reporting success against an
+unreachable database, because the retry loop's success branch was never checked
+against a real failure.
+
+**Dead defence.** Three guards that could not fire: an empty-span check before
+a function that already rejects empty spans, an empty-content check before one
+that already treats empty as noise, and an `http.Client` field no code ever
+assigned. All removed. A guard that cannot fail is not protection, it is a
+second opinion that will eventually disagree with the first.
+
+**Equivalent mutants.** `if v < 0` against `if v <= 0` where the clamp sets
+zero either way; a comparator on ids that are always distinct; deleting a key
+from an empty map. These cannot be killed and should not be chased. They are
+listed here so the next person does not try.
+
 ## Usage
 
 ```sh

--- a/internal/extraction/entity.go
+++ b/internal/extraction/entity.go
@@ -140,10 +140,12 @@ func ExtractEntities(content string) []string {
 		// England refused" keeps "Bank of England".
 		if sentenceStart.MatchString(content[:loc[0]]) && isCommonSentenceOpener(firstWord(span)) {
 			span = strings.TrimSpace(strings.TrimPrefix(span, firstWord(span)))
-			if span == "" {
-				continue
-			}
 		}
+
+		// A run that was nothing but its opener is now empty, and add rejects
+		// it: isPlausibleEntity has a minimum length. There is deliberately no
+		// guard here for that case -- it would be a second place deciding what
+		// is not an entity, and the two would drift.
 
 		add(span)
 	}

--- a/internal/extraction/entity_test.go
+++ b/internal/extraction/entity_test.go
@@ -206,3 +206,77 @@ func TestExtractEntities_ProducesNothingForContentWithNoNames(t *testing.T) {
 		t.Error("whitespace normalised to a non-empty key")
 	}
 }
+
+// An entity named twice in one memory is one entity.
+//
+// Entities are how two memories about the same subject become one hop apart,
+// and the edge is created per distinct name. Without deduplication a memory
+// that mentions someone twice links to them twice, which inflates every
+// traversal's cost and the relationship count the API reports, while adding no
+// reachability at all.
+func TestExtractEntities_DeduplicatesRepeatedNames(t *testing.T) {
+	got := ExtractEntities("Caroline told Melanie that Caroline had adopted a dog, and Melanie agreed.")
+
+	seen := map[string]int{}
+	for _, e := range got {
+		seen[NormalizeEntity(e)]++
+	}
+	for name, n := range seen {
+		if n > 1 {
+			t.Errorf("entity %q extracted %d times from one memory: repeated mentions "+
+				"must collapse to one node, or every traversal pays for the repetition", name, n)
+		}
+	}
+	if len(seen) != 2 {
+		t.Errorf("got %d distinct entities %v, want Caroline and Melanie", len(seen), got)
+	}
+}
+
+// The invariants the removed guards relied on.
+//
+// ExtractEntities and the rule extractor both used to check for an empty
+// string before handing it on, and both checks were unreachable: the function
+// downstream already rejects empty input. Mutation testing found them because
+// forcing either branch changed nothing.
+//
+// The guards are gone, so these pin what now carries that weight. If either
+// stops rejecting empty input, a memory naming nothing gets an entity, or a
+// line that was only a speaker label becomes a memory.
+func TestEmptyInputIsRejectedWhereItMatters(t *testing.T) {
+	if isPlausibleEntity("") {
+		t.Error("isPlausibleEntity(\"\") = true: a capitalised run that was only a " +
+			"sentence opener would become an entity")
+	}
+	if got := ExtractEntities("The deadline is tomorrow"); len(got) != 0 {
+		t.Errorf("ExtractEntities returned %v for a sentence naming nothing", got)
+	}
+}
+
+// Adjacent spans do not overlap.
+//
+// A quoted title is taken first and its range remembered, so the capitalisation
+// pass does not also emit the words inside it: `"Charlotte's Web"` is one
+// entity, not that plus Charlotte. The check is a half-open comparison, and
+// making either side inclusive would treat a run that merely touches a quoted
+// span as being inside it -- silently dropping the entity next to a title.
+func TestOverlaps_TouchingSpansAreNotOverlapping(t *testing.T) {
+	quoted := [][]int{{10, 20}}
+
+	for _, tt := range []struct {
+		name string
+		span []int
+		want bool
+	}{
+		{"a span ending exactly where the quote begins", []int{5, 10}, false},
+		{"a span beginning exactly where the quote ends", []int{20, 25}, false},
+		{"a span overlapping by one rune at the start", []int{5, 11}, true},
+		{"a span overlapping by one rune at the end", []int{19, 25}, true},
+		{"a span inside the quote", []int{12, 15}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := overlaps(quoted, tt.span); got != tt.want {
+				t.Errorf("overlaps(%v, %v) = %v, want %v", quoted, tt.span, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/extraction/extractor.go
+++ b/internal/extraction/extractor.go
@@ -56,11 +56,12 @@ func Extract(conversation string) []ExtractedMemory {
 			continue
 		}
 
-		// Strip speaker prefix ("user:", "assistant:", "Alice:", etc.)
+		// Strip speaker prefix ("user:", "assistant:", "Alice:", etc.). A line
+		// that was only a label strips to nothing, and classifyLine rejects
+		// that: isNoise treats empty content as noise. No guard here for the
+		// same reason as in ExtractEntities -- one place decides what is not
+		// worth storing.
 		content := stripSpeaker(line)
-		if content == "" {
-			continue
-		}
 
 		mem := classifyLine(content)
 		if mem != nil {

--- a/internal/extraction/extractor_test.go
+++ b/internal/extraction/extractor_test.go
@@ -256,3 +256,29 @@ func TestExtractIgnoresSpeakerOnlyLines(t *testing.T) {
 		t.Errorf("the real utterance was not extracted; got %d memories: %+v", len(got), got)
 	}
 }
+
+// A line that is nothing but a speaker label produces no memory.
+//
+// The rule-based extractor strips a "Name:" prefix, and a line consisting only
+// of that prefix strips to nothing. Storing it would put an empty memory in the
+// graph: retrievable, meaningless, and counted in every total the engine
+// reports.
+//
+// The length filter above does not catch it -- "Caroline Wentworth:" is well
+// over the minimum -- so this is the only thing standing between a transcript's
+// stray label lines and the store.
+func TestRuleExtractor_SkipsLinesThatAreOnlyASpeakerLabel(t *testing.T) {
+	memories, err := RuleExtractor{}.Extract("Caroline Wentworth:\nCaroline said that she adopted a rescue dog named Biscuit.")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	for _, m := range memories {
+		if strings.TrimSpace(m.Content) == "" {
+			t.Error("an empty memory was extracted from a line that was only a speaker label")
+		}
+	}
+	if len(memories) != 1 {
+		t.Errorf("got %d memories from one real line and one bare label: %v", len(memories), memories)
+	}
+}

--- a/internal/extraction/llm.go
+++ b/internal/extraction/llm.go
@@ -128,10 +128,6 @@ type LLMExtractor struct {
 
 	// fallback produces memories when the provider fails. Never nil.
 	fallback Extractor
-
-	// client is the HTTP client used for requests. Nil means
-	// llmDefaultClient. Only tests set this.
-	client *http.Client
 }
 
 // NewLLMExtractor creates an extractor backed by an OpenAI-compatible
@@ -236,12 +232,7 @@ func (e *LLMExtractor) extractViaLLM(conversation string) ([]ExtractedMemory, er
 		req.Header.Set("Authorization", "Bearer "+e.apiKey)
 	}
 
-	client := e.client
-	if client == nil {
-		client = llmDefaultClient
-	}
-
-	resp, err := client.Do(req)
+	resp, err := llmDefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("extraction request: %w", redactExtractionErr(err, e.url))
 	}

--- a/internal/extraction/llm_test.go
+++ b/internal/extraction/llm_test.go
@@ -248,3 +248,50 @@ func TestExtractionPrompt_DemandsSpecifics(t *testing.T) {
 		}
 	}
 }
+
+// A provider that needs no key must not be sent an empty credential.
+//
+// This is the configuration charts/kora/values-quality.yaml recommends: a local
+// Ollama, serving an OpenAI-compatible API, with no key. Sending
+// "Authorization: Bearer " to it is at best noise and at worst a 401 from a
+// gateway that parses the header before deciding it is empty -- and the failure
+// would look like a broken extractor rather than a spurious header.
+func TestLLMExtractor_SendsNoAuthorizationHeaderWithoutAKey(t *testing.T) {
+	var authSeen string
+	var sawHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authSeen = r.Header.Get("Authorization")
+		_, sawHeader = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"[]"}}]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := NewLLMExtractor(srv.URL, "", "test-model").Extract(sampleConversation); err != nil {
+		t.Fatalf("Extract against a keyless provider: %v", err)
+	}
+
+	if sawHeader {
+		t.Errorf("sent Authorization: %q to a provider configured without a key", authSeen)
+	}
+}
+
+// And a provider that does need one gets it.
+func TestLLMExtractor_SendsTheKeyWhenThereIsOne(t *testing.T) {
+	var authSeen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authSeen = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"[]"}}]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := NewLLMExtractor(srv.URL, "sk-secret", "test-model").Extract(sampleConversation); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	if authSeen != "Bearer sk-secret" {
+		t.Errorf("Authorization = %q, want the configured key: a provider that requires "+
+			"authentication would reject every extraction", authSeen)
+	}
+}

--- a/internal/graph/entity_test.go
+++ b/internal/graph/entity_test.go
@@ -8,6 +8,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 
@@ -541,5 +542,43 @@ func TestLinkEntities_RefusesToLinkAcrossProjects(t *testing.T) {
 	if len(got[inA.ID]) != 0 {
 		t.Errorf("a project-A memory was linked to a project-B entity (%v); the "+
 			"memory's own project must be checked, not only the entity's", got[inA.ID])
+	}
+}
+
+// A database that has gone away surfaces as an error, not as silent success.
+//
+// linkOneEntity retries, because concurrent writers to the same entity row
+// collide and that collision is expected. Retrying is only correct if the
+// non-retryable case still fails: a caller told "linked 2 entities" when the
+// database was unreachable has a memory that is not in the graph and no way to
+// know.
+//
+// Mutation testing found this: forcing the success branch true made every
+// failure look like a success, and nothing noticed.
+func TestLinkEntities_UnreachableDatabaseIsAnError(t *testing.T) {
+	repo, ctx := testRepo(t)
+
+	// A pool of its own, closed, so this cannot disturb the shared one.
+	pool, err := NewPool(ctx, os.Getenv("KORA_TEST_DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	pool.Close()
+
+	broken := NewAGERepository(pool, testEmbeddingDim)
+	mem := model.Memory{ID: uuid.New(), ProjectID: newProjectID(t), Content: "Caroline adopted Biscuit"}
+
+	linked, err := broken.LinkEntities(ctx, mem, []string{"Caroline", "Biscuit"})
+	if err == nil {
+		t.Errorf("LinkEntities reported %d entities linked against a closed pool and no error: "+
+			"a caller cannot tell a written graph from an unreachable one", linked)
+	}
+	if linked != 0 {
+		t.Errorf("LinkEntities reported %d entities linked while failing", linked)
+	}
+
+	// The shared repository is untouched by the above.
+	if err := repo.Ping(ctx); err != nil {
+		t.Errorf("the working repository became unusable: %v", err)
 	}
 }

--- a/internal/ranking/scorer_test.go
+++ b/internal/ranking/scorer_test.go
@@ -200,3 +200,54 @@ func TestScore_TypeStillBreaksTies(t *testing.T) {
 			Score(semantic, now), Score(episodic, now))
 	}
 }
+
+// Score decides the order, and identity only breaks ties.
+//
+// TestRankResults asserts the output is sorted by score, but builds its
+// memories with random UUIDs -- so it passes or fails on the luck of the draw
+// if the comparator's branches are swapped. Mutation testing found exactly
+// that: inverting the score comparison left the suite green.
+//
+// Fixed ids here, chosen so identity order contradicts score order. If the
+// comparator ever ranks by id first, the higher-scoring memory comes second
+// and this fails every time rather than one run in two.
+func TestRankResults_ScoreBeatsIdentity(t *testing.T) {
+	now := time.Now().UTC()
+	first := uuid.MustParse("00000000-0000-0000-0000-00000000000a")
+	second := uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffffe")
+
+	// The lower-scoring memory sorts first by id, so id order and score order
+	// disagree.
+	weak := model.MemoryWithContext{
+		Memory:    model.Memory{ID: first, Type: model.MemoryTypeSemantic, CreatedAt: now},
+		Relevance: 0.1,
+	}
+	strong := model.MemoryWithContext{
+		Memory:    model.Memory{ID: second, Type: model.MemoryTypeSemantic, CreatedAt: now},
+		Relevance: 0.9,
+	}
+
+	ranked := RankResults([]model.MemoryWithContext{weak, strong}, 0)
+
+	if ranked[0].Memory.ID != second {
+		t.Errorf("ranked by identity rather than by score: got %s first, want the "+
+			"higher-scoring %s", ranked[0].Memory.ID, second)
+	}
+
+	// And with equal scores, identity is what makes the order repeatable.
+	tieA := model.MemoryWithContext{
+		Memory:    model.Memory{ID: first, Type: model.MemoryTypeSemantic, CreatedAt: now},
+		Relevance: 0.5,
+	}
+	tieB := model.MemoryWithContext{
+		Memory:    model.Memory{ID: second, Type: model.MemoryTypeSemantic, CreatedAt: now},
+		Relevance: 0.5,
+	}
+	for i := 0; i < 5; i++ {
+		tied := RankResults([]model.MemoryWithContext{tieB, tieA}, 0)
+		if tied[0].Memory.ID != first {
+			t.Fatalf("equal scores ordered by %s, want the lower id %s: identical queries "+
+				"must return identical pages", tied[0].Memory.ID, first)
+		}
+	}
+}

--- a/pkg/model/content_test.go
+++ b/pkg/model/content_test.go
@@ -108,3 +108,36 @@ func TestContentTokens_TrimsOnlyAtTheEdges(t *testing.T) {
 		}
 	}
 }
+
+// Punctuation-only words must vanish, not become empty tokens.
+//
+// ContentTokens trims punctuation from a token's edges, which turns "!!!" into
+// nothing at all. Skipping those is what keeps the fingerprint stable: an empty
+// token still joins with a space, so "hello !!! world" would hash as
+// "hello  world" -- two spaces -- and stop matching "hello world".
+//
+// The existing hash tests cannot see this. A string of pure punctuation hashes
+// to "" either way, because joining [""] is still "". It only shows up with
+// real words on both sides, which is the shape a transcript actually produces:
+// "Caroline said -- yes" and "Caroline said yes" are the same fact.
+func TestContentTokens_DropsPunctuationOnlyWords(t *testing.T) {
+	got := ContentTokens("hello !!! world")
+	want := []string{"hello", "world"}
+
+	if len(got) != len(want) {
+		t.Fatalf("ContentTokens(%q) = %q, want %q: a punctuation-only word became a token",
+			"hello !!! world", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("token %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// The consequence, and the reason this matters: the fingerprint decides
+	// which memory is discarded as a duplicate.
+	if ContentHash("hello !!! world") != ContentHash("hello world") {
+		t.Error("punctuation between words changed the content hash: two statements " +
+			"of the same fact would both be stored")
+	}
+}


### PR DESCRIPTION
A second sweep after #84, over the rest of the engine.

| package | before | after |
|---|---|---|
| `internal/extraction` | 24 of 30 | **30 of 30** |
| `internal/graph` | 23 of 24 | **24 of 24** |
| `internal/ranking` | 9 of 15 | 12 of 15 |
| `pkg/model` | 5 of 6 | **6 of 6** |

Three kinds of finding, and only one of them was "write a test".

## Real gaps

- **`ContentHash` changed when punctuation sat between two words.** `hello !!! world` hashed differently from `hello world`, so the same fact stated twice would be stored twice - and this decides which memory is discarded as a duplicate. The existing tests could not see it: a string of pure punctuation hashes to `""` either way.
- **An entity named twice in one memory produced two nodes**, inflating every traversal and the relationship count the API reports.
- **`RankResults` could rank by identity instead of score and stay green**, because the existing test built its memories with random UUIDs. Fixed ids now, chosen so identity order contradicts score order - it fails every time rather than one run in two.
- **`LinkEntities` reported success against an unreachable database.** The retry loop exists because concurrent writers to one entity row collide; that is only correct if the non-retryable case still fails.
- **The LLM extractor’s `Authorization` header, both ways** - absent without a key, which is the configuration `values-quality.yaml` recommends for a local Ollama, and present with one.

## Dead defence, removed

An empty-span check before a function that already rejects empty spans; an empty-content check before one that already treats empty as noise; an `http.Client` field no code ever assigned. **A guard that cannot fire is not protection - it is a second opinion that will eventually disagree with the first.**

## Equivalent mutants, documented not chased

`if v < 0` versus `<= 0` where the clamp sets zero either way, a comparator on ids that are always distinct, a delete from an empty map. Listed in `docs/mutation-testing.md` so the next person does not try.

Golden suite unchanged at 0.917 / 0.856.