### PR TITLE
fix: count and log extraction fallbacks instead of degrading silently

### DIFF
--- a/internal/extraction/llm.go
+++ b/internal/extraction/llm.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/NarayanaSabari/Kora/internal/metrics"
 	"github.com/NarayanaSabari/Kora/pkg/model"
 )
 
@@ -189,14 +191,26 @@ type llmMemory struct {
 // posts a conversation and keeps no copy of the memories it would have
 // produced, so an error return means the content is lost. Rule-based
 // extraction is worse but never fails and needs no network, which makes it the
-// right floor. Every fallback is logged by the caller through the returned
-// memories being visibly rule-shaped, and the reason is attached to the error
-// path below.
+// right floor. Every fallback is recorded here -- a warning and the
+// kora_extraction_fallbacks_total counter -- because the caller cannot see
+// it: Extract returns success either way.
 func (e *LLMExtractor) Extract(conversation string) ([]ExtractedMemory, error) {
 	memories, err := e.extractViaLLM(conversation)
 	if err != nil {
-		// Deliberately not returned: see the doc comment. Surfaced through
-		// slog by the service layer via the wrapped error text.
+		// The error is not returned, because a failing provider must not cost
+		// the caller a conversation. It is recorded here rather than left to
+		// the caller, which is a change: the comment used to claim the service
+		// layer surfaced it, and the service layer cannot -- Extract returns
+		// success, so there is nothing there to surface.
+		//
+		// Found by running the engine against a small local model, seeing
+		// transcript lines come back as memories, and having to infer from
+		// their shape that the LLM pass had failed. A deployment whose
+		// provider has been down for a week looked exactly like a healthy one.
+		metrics.ExtractionFallbacks.WithLabelValues("error").Inc()
+		slog.Warn("LLM extraction failed; the rule-based extractor answered instead",
+			slog.String("model", e.model),
+			slog.Any("error", err))
 		return e.fallback.Extract(conversation)
 	}
 	if len(memories) == 0 {
@@ -204,7 +218,30 @@ func (e *LLMExtractor) Extract(conversation string) ([]ExtractedMemory, error) {
 		// held nothing, or the model misunderstood the task. The rule-based
 		// pass is cheap and settles it: if it also finds nothing, there was
 		// nothing.
-		return e.fallback.Extract(conversation)
+		fallback, ferr := e.fallback.Extract(conversation)
+
+		// The disagreement is the signal, not the empty result on its own. A
+		// conversation of greetings genuinely holds nothing and both passes
+		// say so, which is normal and must not warn -- an operator trained to
+		// ignore this warning will ignore the one that matters. A model that
+		// returns nothing from a conversation the rule-based scanner finds
+		// plenty in is not reading the task, and that is worth waking up for.
+		//
+		// Measured while validating this: a 3B model returned an empty array
+		// for a transcript the rule-based pass turned into 26 memories, and
+		// the only visible symptom was memories that read like transcript
+		// lines.
+		if len(fallback) > 0 {
+			metrics.ExtractionFallbacks.WithLabelValues("empty").Inc()
+			slog.Warn("LLM extraction found nothing in a conversation the rule-based extractor did; the model may not be following the task",
+				slog.String("model", e.model),
+				slog.Int("rule_based_memories", len(fallback)))
+		} else {
+			slog.Debug("neither extractor found anything in this conversation",
+				slog.String("model", e.model))
+		}
+
+		return fallback, ferr
 	}
 	return memories, nil
 }

--- a/internal/extraction/llm_test.go
+++ b/internal/extraction/llm_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/NarayanaSabari/Kora/internal/metrics"
 	"github.com/NarayanaSabari/Kora/pkg/model"
 )
 
@@ -294,4 +297,102 @@ func TestLLMExtractor_SendsTheKeyWhenThereIsOne(t *testing.T) {
 		t.Errorf("Authorization = %q, want the configured key: a provider that requires "+
 			"authentication would reject every extraction", authSeen)
 	}
+}
+
+// A provider that fails must be visible, not just survivable.
+//
+// The fallback to the rule-based extractor is deliberate: losing a
+// conversation because a provider is down is worse than storing a cruder
+// version of it. But Extract returns success either way, so a deployment whose
+// provider has been failing for a week looked exactly like a healthy one, and
+// the only symptom was memories that read like transcript lines.
+//
+// Found by running the engine against a small local model and having to infer
+// from the shape of the output that the LLM pass had failed.
+func TestLLMExtractor_FallbackIsCounted(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		handler http.HandlerFunc
+		reason  string
+	}{
+		{
+			name: "a provider that errors",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			reason: "error",
+		},
+		{
+			name: "a provider that answers with nothing",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"[]"}}]}`))
+			},
+			reason: "empty",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			before := counterValue(t, tt.reason)
+
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			got, err := NewLLMExtractor(srv.URL, "k", "m").Extract(sampleConversation)
+			if err != nil {
+				t.Fatalf("a failing provider cost the caller the conversation: %v", err)
+			}
+			if len(got) == 0 {
+				t.Error("the rule-based fallback produced nothing; the conversation was lost silently")
+			}
+
+			if after := counterValue(t, tt.reason); after <= before {
+				t.Errorf("kora_extraction_fallbacks_total{reason=%q} did not move (%v to %v): "+
+					"a degraded deployment is indistinguishable from a healthy one",
+					tt.reason, before, after)
+			}
+		})
+	}
+}
+
+// A conversation that is genuinely empty must not count as a fallback.
+//
+// The "empty" reason means disagreement: the model found nothing where the
+// rule-based pass found memories. When both extractors agree there is nothing,
+// that is healthy traffic -- a conversation of greetings -- and a counter that
+// fires on healthy traffic cannot be alerted on.
+func TestLLMExtractor_AgreedEmptyIsNotCounted(t *testing.T) {
+	before := counterValue(t, "empty")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"[]"}}]}`))
+	}))
+	defer srv.Close()
+
+	// "hi" carries no extractable facts: the rule-based pass also finds
+	// nothing, so the two extractors agree.
+	got, err := NewLLMExtractor(srv.URL, "k", "m").Extract("user: hi")
+	if err != nil {
+		t.Fatalf("an empty conversation must not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no memories from an empty conversation, got %d", len(got))
+	}
+
+	if after := counterValue(t, "empty"); after != before {
+		t.Errorf("kora_extraction_fallbacks_total{reason=%q} moved (%v to %v) on healthy traffic: "+
+			"an operator alerted on this counter would be paged by every small talk",
+			"empty", before, after)
+	}
+}
+
+// counterValue reads one label of the fallback counter.
+func counterValue(t *testing.T, reason string) float64 {
+	t.Helper()
+
+	c, err := metrics.ExtractionFallbacks.GetMetricWithLabelValues(reason)
+	if err != nil {
+		t.Fatalf("counter %q: %v", reason, err)
+	}
+	return testutil.ToFloat64(c)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -72,6 +72,30 @@ var (
 		[]string{"verdict"},
 	)
 
+	// ExtractionFallbacks counts conversations the configured LLM extractor
+	// could not handle, so the rule-based scanner answered instead.
+	//
+	// The fallback is deliberate -- losing a conversation because a provider
+	// is down is worse than storing a cruder version of it -- but it is a
+	// quality change the caller is never told about: Extract returns success
+	// either way. Without this, a deployment whose provider has been failing
+	// for a week looks identical to one whose provider works, and the only
+	// symptom is memories that read like transcript lines.
+	//
+	// "error" means the call failed. "empty" means it succeeded, returned
+	// nothing, and the rule-based pass then found memories in the same text:
+	// the disagreement, not the empty result, is the signal. A conversation
+	// both extractors find empty is not counted, because it is the normal
+	// outcome for a conversation of greetings, and a metric that fires on
+	// healthy traffic cannot be alerted on.
+	ExtractionFallbacks = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kora_extraction_fallbacks_total",
+			Help: "Conversations the rule-based extractor answered because the LLM extractor failed or missed content, by reason.",
+		},
+		[]string{"reason"},
+	)
+
 	// QueryDuration observes the latency of query requests in seconds.
 	QueryDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -218,6 +242,7 @@ func Register() {
 		MemoriesTotal,
 		EdgesTotal,
 		MemoriesConsolidated,
+		ExtractionFallbacks,
 		QueryDuration,
 		StoreDuration,
 		QueryResultsCount,


### PR DESCRIPTION
The LLM extractor falls back to the rule-based scanner when the provider
call fails or returns nothing. Both paths were invisible: Extract returns
success either way, and the doc comment claimed the caller surfaced the
failure, which the caller cannot do. A deployment whose provider had been
failing for a week looked identical to a healthy one, and the only
symptom was memories that read like transcript lines.

Found by running the engine against a small local model and having to
infer from the shape of the output that the LLM pass had failed: the
model returned an empty array for a transcript the rule-based pass
turned into 26 memories.

A failed call now warns with the model and error and increments
kora_extraction_fallbacks_total{reason="error"}. An empty result counts
and warns only on disagreement, when the rule-based pass finds memories
the model did not, because a conversation both extractors find empty is
healthy traffic and a counter that fires on small talk cannot be
alerted on.
