### PR TITLE
docs: re-audit the failure buckets with two independent judges

### DIFF
--- a/docs/plan-of-record.md
+++ b/docs/plan-of-record.md
@@ -86,3 +86,14 @@ Results land in `docs/research/` with per-question labels so runs stay comparabl
 
 At n=40, with a judge that has graded the same answer both ways in different runs, no improvement smaller than about 10 points is claimed.
 Move to the full 200-question set before any decision that depends on a smaller difference.
+
+## Phase F: the graph read path (spec: issue #86)
+
+Settled 2026-08-30 after the two-judge re-audit ([failure-buckets-two-judge](research/failure-buckets-two-judge.md)).
+
+The claim "graph memory engine, not RAG" becomes falsifiable: an ablation switch collapses retrieval to FTS+vector, and graph-on against graph-off on the pinned 200-question set is measured continuously.
+Four read-path changes connect structure the engine already writes: supersedes demotion, entity IDF, entity linking, `relates_to` expansion.
+One PR per change; every weight measured, never chosen; accept on McNemar p < 0.05 with both judges agreeing in direction; two consecutive failures trigger reassessment.
+
+The re-audit resizes expectations, not the design: answering failures dominate LoCoMo (45 of 51 high-confidence failures had the evidence retrieved), so Phase F's payoff is measured by the ablation gap and the capability suites, not by the headline accuracy.
+The answering bucket belongs to the harness-prompt control and hedging work, which follow it.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -32,6 +32,7 @@ produced each published number. Read it before quoting a benchmark figure.
 | [performance-audit-2026-08](performance-audit-2026-08.md) | 2026-08 | Implemented: property indexes, batched edge creation, counts from AGE base tables |
 | [performance-remaining-2026-08](performance-remaining-2026-08.md) | 2026-08 | Partially implemented; the trigram and tsvector work is not done |
 | [keyword-search-indexing](keyword-search-indexing.md) | 2026-08 | Findings folded into the ranking fixes; the indexing approach is open |
+| [failure-buckets-two-judge](failure-buckets-two-judge.md) | 2026-08 | Re-audit of the 200-question failures with two independent judges; answering dominates (45 of 51 high-confidence failures had evidence retrieved, 28 at rank 1) and 19.5% of the benchmark is judge-disputed |
 | [improvement-plan-2026-08](improvement-plan-2026-08.md) | 2026-08 | Items 4-6 implemented (write-time fold, entity nodes, full-text search); item 0 was run and bought one question of 40, see [benchmark-harness](benchmark-harness.md); items 1-3 are sequenced in the [plan of record](../plan-of-record.md) |
 | [benchmark-harness](benchmark-harness.md) | 2026-08, current | Harness custody and run provenance. Kept current rather than point-in-time |
 

--- a/docs/research/failure-buckets-two-judge.md
+++ b/docs/research/failure-buckets-two-judge.md
@@ -1,0 +1,48 @@
+# Failure buckets, re-audited with two judges
+
+**Date:** 2026-08-30.
+**Method:** the 200-question pinned LoCoMo set (`memorybench data/pinned/locomo-200.json`), scored independently by two judge models from different vendors: `gemini-2.5-flash` (run `kora-locomo-200`) and `z-ai/glm-5.3-flash` (run `glm-baseline-200`, same answers re-generated and re-judged end to end by GLM).
+**Supersedes** the single-judge bucket split (20 answering / 22 stored-but-not-retrieved / 29 absent) previously quoted from `kora-locomo-200` alone.
+
+## Headline
+
+| classification | n | share |
+|---|---|---|
+| both judges correct | 110 | 55% |
+| both judges incorrect (high-confidence failures) | 51 | 25.5% |
+| judges disagree | 39 | **19.5%** |
+
+Nearly one question in five is judge-disputed.
+The disputes concentrate in single-hop (13) and adversarial (12), which explains how the two judges produced near-identical totals (0.645 vs 0.650) while disagreeing by 30 points on the adversarial category.
+Any single-judge category number carries roughly that much noise; per the plan of record, no change is accepted unless both judges move in the same direction.
+
+## The 51 high-confidence failures
+
+By question type: temporal 15, single-hop 15, multi-hop 9, world-knowledge 9, adversarial 3.
+
+By where the evidence ranked in the retrieved top-10 (harness `hitAtK`/`mrr` against LoCoMo evidence annotations):
+
+| evidence position | n | reading |
+|---|---|---|
+| rank 1 | 28 | pure answering failure: the engine put the evidence first and the answer was still wrong under both judges |
+| rank 2-3 | 11 | answering failure; ranking nearly ideal |
+| rank 4-10 | 6 | answering failure; better ranking might help at the margin |
+| not in top-10 | 6 | retrieval failure or absent from store |
+
+## What this changes
+
+1. **Answering, not retrieval, dominates the high-confidence failures: 45 of 51 had the evidence retrieved, 28 at rank 1.**
+   The earlier single-judge audit overstated the retrieval-side buckets because judge-disputed questions and heuristic evidence matching were folded into them.
+2. **The realistic yield from retrieval-side work on this benchmark is small: at most ~6 questions (3 points) from the not-in-top-10 bucket, plus margins on the 17 ranked 2-10.**
+   The graph read-path programme (#86) keeps its own justification - the ablation gate, supersedes correctness, capability classes RAG cannot serve - but LoCoMo accuracy is not where its payoff will show first.
+3. **The answering bucket splits along the engine/harness boundary.**
+   The harness's shared answer prompt (#58 control) and hedging/inference behaviour (#56) own most of it; extraction phrasing (#74) can still matter because *how* a memory is worded decides whether a rank-1 hit is answerable.
+4. **The judge-disputed 39 are not an engine work item at all.**
+   They are grader variance; the two-judge protocol exists precisely to keep them out of accept/revert decisions.
+
+## Caveats
+
+- `hitAtK` is the harness's fuzzy match between LoCoMo evidence annotations and retrieved text; it can over-credit retrieval when a paraphrase matches without carrying the answer.
+  The 28 rank-1 failures were not hand-verified individually.
+- Both runs answered with different models (Gemini vs GLM), so "both judges incorrect" conflates answering-model variance with grading variance for a handful of questions.
+  The direction of the headline survives this: even under the more favourable single-run reading, evidence was retrieved for the large majority of failures.


### PR DESCRIPTION
The single-judge split (20 answering / 22 stored-but-not-retrieved / 29
absent) does not survive a second grader. Scoring the pinned 200-question
set with gemini-2.5-flash and glm-5.3-flash independently: 39 questions
(19.5%) are judge-disputed, and of the 51 failures both judges agree on,
45 had the evidence retrieved in the top-10 -- 28 of them at rank 1,
where retrieval cannot do better.

Answering, not retrieval, dominates the benchmark's failures. The plan
of record gains Phase F recording what this resizes: the graph read-path
programme (#86) is justified by the ablation gap and capability suites,
not by expected LoCoMo yield.
