### PR TITLE
feat: one switch that turns off every graph retrieval signal

### DIFF
--- a/api/gen/kora/v1/health.pb.go
+++ b/api/gen/kora/v1/health.pb.go
@@ -96,8 +96,18 @@ type HealthResponse struct {
 	// A field rather than a status of "degraded": the engine is healthy, and a
 	// monitoring system that pages on this would be wrong.
 	ZeroDependencyDefaults bool `protobuf:"varint,7,opt,name=zero_dependency_defaults,json=zeroDependencyDefaults,proto3" json:"zero_dependency_defaults,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// True when the graph's retrieval signals are switched off
+	// (KORA_GRAPH_SIGNALS=off) and queries are answered by full-text and
+	// vector search alone.
+	//
+	// This is the ablation mode: it exists to measure what the graph
+	// contributes, by comparing a deployment in this mode against a normal one
+	// on the same corpus. A benchmark number from a deployment with this set
+	// is a measurement of the ablated engine, not of Kora, and this field is
+	// what lets a caller tell the two apart.
+	GraphSignalsDisabled bool `protobuf:"varint,8,opt,name=graph_signals_disabled,json=graphSignalsDisabled,proto3" json:"graph_signals_disabled,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *HealthResponse) Reset() {
@@ -179,12 +189,19 @@ func (x *HealthResponse) GetZeroDependencyDefaults() bool {
 	return false
 }
 
+func (x *HealthResponse) GetGraphSignalsDisabled() bool {
+	if x != nil {
+		return x.GraphSignalsDisabled
+	}
+	return false
+}
+
 var File_kora_v1_health_proto protoreflect.FileDescriptor
 
 const file_kora_v1_health_proto_rawDesc = "" +
 	"\n" +
 	"\x14kora/v1/health.proto\x12\akora.v1\x1a\x1cgoogle/api/annotations.proto\"\x0f\n" +
-	"\rHealthRequest\"\x9a\x02\n" +
+	"\rHealthRequest\"\xd0\x02\n" +
 	"\x0eHealthResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x1d\n" +
@@ -194,7 +211,8 @@ const file_kora_v1_health_proto_rawDesc = "" +
 	"edge_count\x18\x04 \x01(\x03R\tedgeCount\x12-\n" +
 	"\x12embedding_provider\x18\x05 \x01(\tR\x11embeddingProvider\x12/\n" +
 	"\x13extraction_provider\x18\x06 \x01(\tR\x12extractionProvider\x128\n" +
-	"\x18zero_dependency_defaults\x18\a \x01(\bR\x16zeroDependencyDefaults2^\n" +
+	"\x18zero_dependency_defaults\x18\a \x01(\bR\x16zeroDependencyDefaults\x124\n" +
+	"\x16graph_signals_disabled\x18\b \x01(\bR\x14graphSignalsDisabled2^\n" +
 	"\rHealthService\x12M\n" +
 	"\x06Health\x12\x16.kora.v1.HealthRequest\x1a\x17.kora.v1.HealthResponse\"\x12\x82\xd3\xe4\x93\x02\f\x12\n" +
 	"/v1/healthB7Z5github.com/NarayanaSabari/Kora/api/gen/kora/v1;korav1b\x06proto3"

--- a/api/proto/kora/v1/health.proto
+++ b/api/proto/kora/v1/health.proto
@@ -62,4 +62,15 @@ message HealthResponse {
   // A field rather than a status of "degraded": the engine is healthy, and a
   // monitoring system that pages on this would be wrong.
   bool zero_dependency_defaults = 7;
+
+  // True when the graph's retrieval signals are switched off
+  // (KORA_GRAPH_SIGNALS=off) and queries are answered by full-text and
+  // vector search alone.
+  //
+  // This is the ablation mode: it exists to measure what the graph
+  // contributes, by comparing a deployment in this mode against a normal one
+  // on the same corpus. A benchmark number from a deployment with this set
+  // is a measurement of the ablated engine, not of Kora, and this field is
+  // what lets a caller tell the two apart.
+  bool graph_signals_disabled = 8;
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -145,7 +145,11 @@ func main() {
 	// Not fatal, and not a "degraded" health status: no network egress on a
 	// fresh install is the right default, and paging on it would be wrong.
 	// Loud once, at startup, where an operator is looking.
-	providers := service.Providers{Embedding: cfg.EmbeddingProvider, Extraction: cfg.ExtractionProvider}
+	providers := service.Providers{
+		Embedding:            cfg.EmbeddingProvider,
+		Extraction:           cfg.ExtractionProvider,
+		GraphSignalsDisabled: cfg.GraphSignals == "off",
+	}
 	if providers.ZeroDependencyDefaults() {
 		slog.Warn("running on zero-dependency defaults: hashed bag-of-words embeddings and rule-based extraction",
 			slog.String("embedding_provider", cfg.EmbeddingProvider),
@@ -181,6 +185,16 @@ func main() {
 
 	// Register all service implementations on the gRPC server.
 	memorySvc := service.NewMemoryServiceWithExtractor(repo, embedder, extractor)
+	if cfg.GraphSignals == "off" {
+		// The ablation mode, issue #86. Loud for the same reason the
+		// zero-dependency warning is: a benchmark number produced against this
+		// deployment measures the ablated engine, and the only place that is
+		// visible later is this line and the health endpoint.
+		memorySvc.DisableGraphSignals()
+		slog.Warn("graph signals disabled: retrieving by full-text and vector search alone",
+			slog.String("reason", "KORA_GRAPH_SIGNALS=off"),
+			slog.String("effect", "this deployment behaves as plain hybrid RAG; entity retrieval is off"))
+	}
 	sessionSvc := service.NewSessionService(repo)
 	healthSvc := service.NewHealthService(repo, cfg.Version, providers)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@
 //	KORA_EXTRACTION_MODEL   Chat model for LLM extraction (default: gpt-4o-mini)
 //	KORA_EXTRACTION_API_KEY API key for the extraction provider (default: "")
 //	KORA_EXTRACTION_BASE_URL OpenAI-compatible endpoint (default: https://api.openai.com)
+//	KORA_GRAPH_SIGNALS      "on" | "off": whether graph signals join retrieval (default: on)
 //
 // Metadata:
 //
@@ -96,6 +97,20 @@ type Config struct {
 	// EmbeddingDim is the vector dimension. When 0, the provider auto-detects it.
 	// Env: KORA_EMBEDDING_DIM (default: 0)
 	EmbeddingDim int
+
+	// GraphSignals reports whether the graph participates in retrieval.
+	//
+	// "off" is the ablation mode: queries are answered by full-text and
+	// vector search alone, which is what the engine would be if it were plain
+	// hybrid RAG. It exists so that the difference between that and normal
+	// operation is a measurement instead of a claim -- see issue #86 -- and
+	// doubles as the honest baseline when comparing Kora against RAG systems.
+	//
+	// Every graph-derived retrieval signal hangs off this one switch, so an
+	// ablation run cannot accidentally disable some signals and not others.
+	//
+	// Env: KORA_GRAPH_SIGNALS ("on" or "off", default: "on")
+	GraphSignals string
 
 	// ExtractionProvider selects how conversations are turned into memories.
 	// Accepted values: "rule" (default) or "llm".
@@ -172,6 +187,7 @@ func Load() Config {
 		EmbeddingBaseURL:  getEnv("KORA_EMBEDDING_BASE_URL", ""),
 		EmbeddingDim:      getEnvInt("KORA_EMBEDDING_DIM", 0),
 
+		GraphSignals:       getEnv("KORA_GRAPH_SIGNALS", "on"),
 		ExtractionProvider: getEnv("KORA_EXTRACTION_PROVIDER", "rule"),
 		ExtractionModel:    getEnv("KORA_EXTRACTION_MODEL", "gpt-4o-mini"),
 		ExtractionAPIKey:   getEnv("KORA_EXTRACTION_API_KEY", ""),
@@ -307,6 +323,15 @@ func (c Config) Validate() error {
 		problems = append(problems,
 			fmt.Sprintf("KORA_RATE_LIMIT_PER_MINUTE=%d must be positive; "+
 				"a non-positive limit rejects every request", c.RateLimitPerMinute))
+	}
+
+	// An unrecognised value must not silently mean either mode. "of" -- a
+	// typo for "off" -- silently running the full engine would invalidate the
+	// ablation measurement it was meant to produce, in the direction that
+	// flatters the graph.
+	if c.GraphSignals != "on" && c.GraphSignals != "off" {
+		problems = append(problems,
+			fmt.Sprintf("KORA_GRAPH_SIGNALS=%q is neither \"on\" nor \"off\"", c.GraphSignals))
 	}
 
 	// A negative dimension would be handed to the pgvector column definition.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -185,6 +185,12 @@ func TestValidateRejectsOutOfRangeValues(t *testing.T) {
 			why:  "one of the two listeners would fail to bind",
 		},
 		{
+			name: "graph signals set to neither on nor off",
+			env:  map[string]string{"KORA_GRAPH_SIGNALS": "of"},
+			why: "a typo silently running the full engine would invalidate the ablation " +
+				"measurement in the direction that flatters the graph",
+		},
+		{
 			name: "zero rate limit",
 			env:  map[string]string{"KORA_RATE_LIMIT_PER_MINUTE": "0"},
 			why:  "a bucket that never refills rejects every request, which looks like an outage",

--- a/internal/retrieval/ablation_test.go
+++ b/internal/retrieval/ablation_test.go
@@ -1,0 +1,82 @@
+package retrieval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NarayanaSabari/Kora/pkg/model"
+	"github.com/google/uuid"
+)
+
+// The ablation contract, issue #86: DisableGraphSignals leaves an engine that
+// retrieves by full-text and vector search alone, indistinguishable from a
+// stack in which the graph signals do not exist. Both directions are pinned --
+// the switch must remove the signal, and the default must keep it -- because a
+// mutant that inverts or ignores the flag turns every ablation measurement
+// into a comparison of the engine with itself.
+
+// entityOnlyFixture returns a repo where one memory is reachable only through
+// the entity retriever: keyword and vector search know nothing of it.
+func entityOnlyFixture() (*fakeRepo, model.MemoryWithContext, model.Memory) {
+	keywordHit := memory("the deploy target is production")
+	entityHit := model.Memory{
+		ID:      uuid.New(),
+		Content: "Biscuit trembles during thunderstorms",
+		Type:    model.MemoryTypeSemantic,
+	}
+	return &fakeRepo{
+		textResults:   []model.MemoryWithContext{keywordHit},
+		searchable:    true,
+		entityResults: []model.Memory{entityHit},
+	}, keywordHit, entityHit
+}
+
+func TestRetrieve_GraphSignalsOffSkipsEntityRetrieval(t *testing.T) {
+	repo, keywordHit, entityHit := entityOnlyFixture()
+
+	eng := New(repo, fixedEmbedder{})
+	eng.DisableGraphSignals()
+
+	// "Biscuit" is a rule-extractable entity, so with signals on this query
+	// would reach the entity retriever.
+	results, err := eng.Retrieve(context.Background(), "What scares Biscuit?", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+
+	if repo.entityCalls != 0 {
+		t.Errorf("entity retriever consulted %d times with graph signals off: "+
+			"the ablated engine is not the RAG baseline it claims to be", repo.entityCalls)
+	}
+	for _, r := range results {
+		if r.Memory.ID == entityHit.ID {
+			t.Errorf("entity-only memory %q surfaced with graph signals off", r.Memory.Content)
+		}
+	}
+	if len(results) == 0 || results[0].Memory.ID != keywordHit.Memory.ID {
+		t.Errorf("keyword retrieval should be untouched by the ablation; got %d results", len(results))
+	}
+}
+
+// The control: by default the same fixture does surface the entity-only
+// memory. Without this, a mutant that disables the graph signals
+// unconditionally passes the test above and every ablation run measures
+// nothing.
+func TestRetrieve_GraphSignalsOnReachEntityOnlyMemories(t *testing.T) {
+	repo, _, entityHit := entityOnlyFixture()
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "What scares Biscuit?", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+
+	if repo.entityCalls == 0 {
+		t.Fatal("entity retriever never consulted on a default engine")
+	}
+	for _, r := range results {
+		if r.Memory.ID == entityHit.ID {
+			return
+		}
+	}
+	t.Error("entity-only memory did not surface on a default engine: the graph signal is dead")
+}

--- a/internal/retrieval/degradation_test.go
+++ b/internal/retrieval/degradation_test.go
@@ -37,8 +37,11 @@ type fakeRepo struct {
 	vectorErr     error
 	entityErr     error
 
+	entityResults []model.Memory
+
 	queryMemoriesCalled bool
 	searchByVectorCalls int
+	entityCalls         int
 }
 
 func (f *fakeRepo) SearchByText(context.Context, string, []string, int) ([]model.MemoryWithContext, error) {
@@ -60,7 +63,8 @@ func (f *fakeRepo) SearchByVector(context.Context, []float32, string, int) ([]mo
 }
 
 func (f *fakeRepo) FindMemoriesByEntities(context.Context, string, []string, int) ([]model.Memory, error) {
-	return nil, f.entityErr
+	f.entityCalls++
+	return f.entityResults, f.entityErr
 }
 
 func (f *fakeRepo) GetMemoryEntities(context.Context, []uuid.UUID) (map[uuid.UUID][]string, error) {

--- a/internal/retrieval/retrieval.go
+++ b/internal/retrieval/retrieval.go
@@ -54,11 +54,30 @@ type Repo interface {
 type Engine struct {
 	repo     Repo
 	embedder embedding.Embedder
+
+	// graphSignalsOff removes every graph-derived signal from retrieval.
+	// Set once at startup via DisableGraphSignals; see that method.
+	graphSignalsOff bool
 }
 
 // New returns an Engine. The embedder may be nil.
 func New(repo Repo, embedder embedding.Embedder) *Engine {
 	return &Engine{repo: repo, embedder: embedder}
+}
+
+// DisableGraphSignals removes every graph-derived signal from retrieval,
+// leaving full-text and vector search alone. One switch for all of them, so an
+// ablation run cannot accidentally disable some signals and not others.
+//
+// This is the ablation mode (issue #86): the engine behaves as plain hybrid
+// RAG, and the measured gap between that and normal operation is what the
+// graph contributes. Not a tuning knob -- a deployment that wants less of one
+// signal wants a ranking change, not this.
+//
+// Startup-only: call it before the engine serves queries. It writes an
+// unsynchronised field that Retrieve reads.
+func (e *Engine) DisableGraphSignals() {
+	e.graphSignalsOff = true
 }
 
 // Retrieve answers a query: three retrievers, merged onto one scale, ranked,
@@ -201,8 +220,12 @@ func (e *Engine) Retrieve(
 	// memory containing any query word however common -- which made the recall
 	// half of this feature unreachable in every project with more than a
 	// handful of keyword matches.
-	entityResults, entityOverlap := e.entityMatches(ctx, projectID, query, filter.TopK,
-		graphResults, vectorResults)
+	var entityResults []model.Memory
+	var entityOverlap map[uuid.UUID]float64
+	if !e.graphSignalsOff {
+		entityResults, entityOverlap = e.entityMatches(ctx, projectID, query, filter.TopK,
+			graphResults, vectorResults)
+	}
 
 	// Merge: deduplicate by ID, and put the three retrievers' signals on one
 	// scale. Keywords are passed so the merge can tell a candidate that

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -68,6 +68,13 @@ type healthRepo interface {
 type Providers struct {
 	Embedding  string
 	Extraction string
+
+	// GraphSignalsDisabled reports the ablation mode: retrieval running on
+	// full-text and vector search alone (KORA_GRAPH_SIGNALS=off). Reported for
+	// the same reason as the providers -- a benchmark number from an ablated
+	// deployment measures the ablated engine, and a caller comparing two
+	// deployments needs to see which one they are looking at.
+	GraphSignalsDisabled bool
 }
 
 // ZeroDependencyDefaults reports whether both providers are the offline
@@ -145,6 +152,7 @@ func (s *HealthService) Health(ctx context.Context, _ *pb.HealthRequest) (*pb.He
 		EmbeddingProvider:      s.providers.Embedding,
 		ExtractionProvider:     s.providers.Extraction,
 		ZeroDependencyDefaults: s.providers.ZeroDependencyDefaults(),
+		GraphSignalsDisabled:   s.providers.GraphSignalsDisabled,
 	}, nil
 }
 

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -443,3 +443,22 @@ func TestHealth_ProviderNamesSurviveToTheResponse(t *testing.T) {
 		t.Error("a deployment running Ollama and an LLM extractor is not on zero-dependency defaults")
 	}
 }
+
+// The ablation mode must be visible to an authenticated caller.
+//
+// A benchmark number produced against an ablated deployment measures the
+// ablated engine, and this field is the only way to tell the two apart after
+// the fact. See issue #86.
+func TestHealthReportsGraphSignalsDisabled(t *testing.T) {
+	h := &HealthService{repo: &countingRepo{}, version: "test",
+		providers: Providers{GraphSignalsDisabled: true}}
+
+	resp, err := h.Health(authedCtx(), &pb.HealthRequest{})
+	if err != nil {
+		t.Fatalf("health: %v", err)
+	}
+	if !resp.GraphSignalsDisabled {
+		t.Error("graph_signals_disabled not reported: an ablated deployment is " +
+			"indistinguishable from a normal one, which is the defect the field exists to prevent")
+	}
+}

--- a/internal/service/memory.go
+++ b/internal/service/memory.go
@@ -84,6 +84,13 @@ func NewMemoryServiceWithExtractor(repo *graph.AGERepository, embedder embedding
 	}
 }
 
+// DisableGraphSignals switches the retrieval engine to full-text and vector
+// search alone: the ablation mode, issue #86. Startup-only, before the
+// service answers queries; see retrieval.Engine.DisableGraphSignals.
+func (s *MemoryService) DisableGraphSignals() {
+	s.retrieval.DisableGraphSignals()
+}
+
 // Store persists a new memory node into the graph. The full pipeline is:
 //  1. Validate input (content and project_id are required).
 //  2. Create the memory node in the graph repository.


### PR DESCRIPTION
KORA_GRAPH_SIGNALS=off collapses retrieval to full-text and vector
search alone: the engine as it would be if it were plain hybrid RAG.

The switch exists to make a claim falsifiable. The project calls itself
a graph memory engine, but nothing measured what the graph contributes
at query time; graph-on against graph-off on the same corpus and the
same pinned question set is that measurement, and the ablated mode
doubles as the honest baseline when comparing against RAG systems.

One switch for all graph signals rather than one per signal, so an
ablation run cannot disable some and not others. Today it governs the
entity retriever; every signal the read-path programme adds (issue #86)
hangs off the same field.

Loud in the places an operator looks, following the degraded-mode
pattern: a startup warning, and graph_signals_disabled on the health
response -- a benchmark number from an ablated deployment measures the
ablated engine, and the health field is what tells the two apart after
the fact. An unrecognised value fails validation rather than guessing:
a typo silently running the full engine would invalidate the
measurement in the direction that flatters the graph.

Both directions of the switch are pinned by tests: off skips the entity
retriever and surfaces nothing through it; the default reaches a memory
findable only through an entity. A mutant that inverts or ignores the
flag turns every ablation run into a comparison of the engine with
itself.
