### PR TITLE
feat: weight entity matches by how much the entity discriminates

### DIFF
--- a/internal/graph/entity.go
+++ b/internal/graph/entity.go
@@ -401,3 +401,94 @@ func (r *AGERepository) GetMemoryEntities(ctx context.Context, ids []uuid.UUID) 
 	}
 	return result, nil
 }
+
+// EntityMentionStats reports, for each of the given entity names, how many of
+// the project's memories mention it, plus the project's total memory count.
+//
+// This is the corpus knowledge behind entity IDF weighting: an entity
+// mentioned by most of a project's memories discriminates nothing, and one
+// mentioned by three memories out of thousands nearly answers the query by
+// itself. The retrieval layer turns these counts into weights; this method
+// only reports them, because how much a count is worth is a ranking decision.
+//
+// Names are normalized the same way FindMemoriesByEntities normalizes them,
+// so a caller can pass the same list to both. Entities the project has never
+// mentioned are absent from the returned map rather than zero, which callers
+// must treat identically.
+func (r *AGERepository) EntityMentionStats(ctx context.Context, projectID string, names []string) (map[string]int64, int64, error) {
+	counts := make(map[string]int64)
+	if len(names) == 0 {
+		return counts, 0, nil
+	}
+
+	normalized := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		key := model.NormalizeEntity(n)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		normalized = append(normalized, key)
+	}
+	if len(normalized) == 0 {
+		return counts, 0, nil
+	}
+
+	p := params{"project_id": projectID}
+	placeholders := make([]string, len(normalized))
+	for i, n := range normalized {
+		name := fmt.Sprintf("en%d", i)
+		placeholders[i] = "$" + name
+		p[name] = n
+	}
+
+	// DISTINCT m, because a memory mentioning an entity through two edges is
+	// still one memory: the count answers "how many memories are about this
+	// entity", not "how many edges name it".
+	q := fmt.Sprintf(
+		`MATCH (m:Memory)-[:%s]->(e:Entity) `+
+			`WHERE e.project_id = $project_id AND m.project_id = $project_id `+
+			`AND e.normalized_name IN [%s] `+
+			`WITH e.normalized_name AS name, count(DISTINCT m) AS mentions `+
+			`RETURN {name: name, mentions: mentions}`,
+		string(model.RelMentions), strings.Join(placeholders, ","),
+	)
+
+	rows, err := r.cypher(ctx, q, p)
+	if err != nil {
+		return nil, 0, fmt.Errorf("entity mention stats: %w", err)
+	}
+	type row struct {
+		Name     string `json:"name"`
+		Mentions int64  `json:"mentions"`
+	}
+	rs, err := scanAgtype[row](rows)
+	if err != nil {
+		return nil, 0, fmt.Errorf("scan entity mention stats: %w", err)
+	}
+	for _, rr := range rs {
+		if rr.Name != "" {
+			counts[rr.Name] = rr.Mentions
+		}
+	}
+
+	totalRows, err := r.cypher(ctx,
+		`MATCH (m:Memory) WHERE m.project_id = $project_id RETURN {total: count(m)}`,
+		params{"project_id": projectID})
+	if err != nil {
+		return nil, 0, fmt.Errorf("project memory count: %w", err)
+	}
+	type totalRow struct {
+		Total int64 `json:"total"`
+	}
+	ts, err := scanAgtype[totalRow](totalRows)
+	if err != nil {
+		return nil, 0, fmt.Errorf("scan project memory count: %w", err)
+	}
+	var total int64
+	if len(ts) > 0 {
+		total = ts[0].Total
+	}
+	return counts, total, nil
+}

--- a/internal/ranking/entity_test.go
+++ b/internal/ranking/entity_test.go
@@ -8,8 +8,8 @@ import "testing"
 func TestEntityBoost_BreaksTiesBetweenEqualMatches(t *testing.T) {
 	const equal = 0.60
 
-	about := ApplyEntityBoost(equal, EntityOverlap([]string{"biscuit"}, []string{"biscuit"}))
-	notAbout := ApplyEntityBoost(equal, EntityOverlap([]string{"pepper"}, []string{"biscuit"}))
+	about := ApplyEntityBoost(equal, EntityOverlap([]string{"biscuit"}, []string{"biscuit"}, nil))
+	notAbout := ApplyEntityBoost(equal, EntityOverlap([]string{"pepper"}, []string{"biscuit"}, nil))
 
 	if about <= notAbout {
 		t.Errorf("a memory naming the query's entity scored %v against %v for one "+
@@ -69,7 +69,7 @@ func TestEntityOverlap_IsTheShareOfTheQuerysEntitiesNamed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EntityOverlap(tt.memory, query); got != tt.want {
+			if got := EntityOverlap(tt.memory, query, nil); got != tt.want {
 				t.Errorf("EntityOverlap(%v, %v) = %v, want %v", tt.memory, query, got, tt.want)
 			}
 		})
@@ -93,7 +93,7 @@ func TestEntityOverlap_IsZeroWhenThereIsNothingToMatch(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EntityOverlap(tt.memory, tt.query); got != 0 {
+			if got := EntityOverlap(tt.memory, tt.query, nil); got != 0 {
 				t.Errorf("EntityOverlap(%v, %v) = %v, want 0", tt.memory, tt.query, got)
 			}
 		})
@@ -103,7 +103,7 @@ func TestEntityOverlap_IsZeroWhenThereIsNothingToMatch(t *testing.T) {
 // A duplicated query entity must not count twice, or a query mentioning one
 // name repeatedly would inflate its own denominator and dilute the match.
 func TestEntityOverlap_CountsDistinctQueryEntities(t *testing.T) {
-	got := EntityOverlap([]string{"caroline"}, []string{"caroline", "caroline", "caroline"})
+	got := EntityOverlap([]string{"caroline"}, []string{"caroline", "caroline", "caroline"}, nil)
 	if got != 1 {
 		t.Errorf("EntityOverlap = %v, want 1: repeating an entity in the query "+
 			"does not make it harder to match", got)
@@ -166,5 +166,63 @@ func TestEntityMatch_LosesToAStrongLexicalMatch(t *testing.T) {
 		t.Errorf("an entity-only match scored %v against %v for a memory matching "+
 			"every query term; naming the subject is necessary but not sufficient",
 			entityOnly, strongLexical)
+	}
+}
+
+// Weighted overlap: the discrimination weight is the point of entity IDF.
+//
+// Measured on the ablation baseline: the unweighted signal pulled generic
+// entity matches into adversarial questions and hurt 6-to-1, because naming
+// an entity that most of the project's memories name is not evidence. The
+// weight makes a ubiquitous entity worth almost nothing and a rare one worth
+// almost everything, and both directions are pinned here.
+func TestEntityOverlap_WeightsDiscriminateByRarity(t *testing.T) {
+	weights := map[string]float64{
+		"caroline": 0.1, // mentioned by nearly every memory
+		"biscuit":  0.9, // mentioned by three
+	}
+
+	ubiquitous := EntityOverlap([]string{"caroline"}, []string{"caroline"}, weights)
+	rare := EntityOverlap([]string{"biscuit"}, []string{"biscuit"}, weights)
+
+	if ubiquitous != 0.1 {
+		t.Errorf("ubiquitous entity overlap = %v, want its weight 0.1: an entity in "+
+			"every memory must carry almost no signal", ubiquitous)
+	}
+	if rare != 0.9 {
+		t.Errorf("rare entity overlap = %v, want its weight 0.9", rare)
+	}
+	if rare <= ubiquitous {
+		t.Error("a rare shared entity must outweigh a ubiquitous one; that ordering is the feature")
+	}
+}
+
+// Nil weights are the unweighted behaviour, exactly.
+//
+// This is the degradation contract: when mention stats are unavailable the
+// caller passes nil, and retrieval must order candidates precisely as it did
+// before weighting existed -- worse ordering, never a changed result set.
+func TestEntityOverlap_NilWeightsAreUniform(t *testing.T) {
+	memory := []string{"caroline", "biscuit"}
+	query := []string{"caroline", "biscuit", "melanie"}
+
+	if got := EntityOverlap(memory, query, nil); got != 2.0/3.0 {
+		t.Errorf("nil-weight overlap = %v, want 2/3: nil must mean uniform full weight", got)
+	}
+}
+
+// An entity absent from the weights map counts fully.
+//
+// Absence means the store had no mention count for it, and an entity with no
+// mentions cannot be matched at all -- so a full-weight default only ever
+// affects entities that were matched despite the stats missing them, where
+// under-counting real evidence would be the worse error.
+func TestEntityOverlap_UnknownEntityKeepsFullWeight(t *testing.T) {
+	weights := map[string]float64{"caroline": 0.1}
+
+	got := EntityOverlap([]string{"caroline", "miso"}, []string{"caroline", "miso"}, weights)
+	want := (0.1 + 1.0) / 2.0
+	if got != want {
+		t.Errorf("overlap = %v, want %v: unweighted entity must default to full weight", got, want)
 	}
 }

--- a/internal/ranking/relevance.go
+++ b/internal/ranking/relevance.go
@@ -191,8 +191,8 @@ func EntityRelevance(overlap float64) float64 {
 	return clamp01(entityMatchRelevance * clamp01(overlap))
 }
 
-// EntityOverlap reports the share of the query's entities a memory names, in
-// [0, 1].
+// EntityOverlap reports the weighted share of the query's entities a memory
+// names, in [0, 1].
 //
 // Entity match is evidence of a different kind from either retriever's:
 // lexical matching says the words line up and cosine similarity says the
@@ -205,7 +205,19 @@ func EntityRelevance(overlap float64) float64 {
 // normalized from the store. An empty query entity set returns 0 rather than
 // 1: with nothing to match, no memory has earned anything, and returning 1
 // would hand every candidate the full boost and cancel it out.
-func EntityOverlap(memoryEntities, queryEntities []string) float64 {
+//
+// weights scales each matched entity by how much it discriminates, in [0, 1]
+// per entity; a nil map weighs every entity fully, which is the pre-IDF
+// behaviour. The weight exists because a shared entity is only evidence when
+// sharing it is informative. "Caroline" is named by nearly every memory of a
+// corpus about Caroline, so naming her says nothing about which memory
+// answers -- measured on the ablation baseline, where this signal pulled
+// generic entity matches into adversarial questions and hurt 6-to-1 -- while
+// a shared "Biscuit" named by three memories out of thousands is nearly an
+// answer by itself. An entity missing from the map weighs 1.0: an unknown
+// entity cannot be matched at all, so its weight only ever pads the
+// denominator through distinct, exactly as it did before weighting.
+func EntityOverlap(memoryEntities, queryEntities []string, weights map[string]float64) float64 {
 	if len(queryEntities) == 0 || len(memoryEntities) == 0 {
 		return 0
 	}
@@ -215,7 +227,8 @@ func EntityOverlap(memoryEntities, queryEntities []string) float64 {
 		have[e] = true
 	}
 
-	matched, distinct := 0, 0
+	var matched float64
+	distinct := 0
 	seen := make(map[string]bool, len(queryEntities))
 	for _, q := range queryEntities {
 		if q == "" || seen[q] {
@@ -224,13 +237,19 @@ func EntityOverlap(memoryEntities, queryEntities []string) float64 {
 		seen[q] = true
 		distinct++
 		if have[q] {
-			matched++
+			w := 1.0
+			if weights != nil {
+				if ww, ok := weights[q]; ok {
+					w = clamp01(ww)
+				}
+			}
+			matched += w
 		}
 	}
 	if distinct == 0 {
 		return 0
 	}
-	return float64(matched) / float64(distinct)
+	return clamp01(matched / float64(distinct))
 }
 
 // ApplyEntityBoost raises a memory's relevance in proportion to how much of

--- a/internal/retrieval/degradation_test.go
+++ b/internal/retrieval/degradation_test.go
@@ -37,7 +37,11 @@ type fakeRepo struct {
 	vectorErr     error
 	entityErr     error
 
-	entityResults []model.Memory
+	entityResults  []model.Memory
+	memoryEntities map[uuid.UUID][]string
+	entityStats    map[string]int64
+	entityTotal    int64
+	entityStatsErr error
 
 	queryMemoriesCalled bool
 	searchByVectorCalls int
@@ -68,7 +72,11 @@ func (f *fakeRepo) FindMemoriesByEntities(context.Context, string, []string, int
 }
 
 func (f *fakeRepo) GetMemoryEntities(context.Context, []uuid.UUID) (map[uuid.UUID][]string, error) {
-	return nil, nil
+	return f.memoryEntities, nil
+}
+
+func (f *fakeRepo) EntityMentionStats(context.Context, string, []string) (map[string]int64, int64, error) {
+	return f.entityStats, f.entityTotal, f.entityStatsErr
 }
 
 // fixedEmbedder returns a constant vector, or an error.
@@ -297,5 +305,75 @@ func TestRetrieve_WeakVectorOnlyHitsAreGated(t *testing.T) {
 			t.Error("a vector-only hit below the semantic gate was returned: " +
 				"a query with no good match must come back empty rather than plausible")
 		}
+	}
+}
+
+// Failed mention stats degrade to uniform weights, not to a lost signal.
+//
+// The stats call sits inside the entity retriever, and a database that can
+// find memories by entity but not count mentions is one bad query plan away.
+// The contract: the entity results still arrive, still carry overlap, and the
+// only casualty is the discrimination weighting.
+func TestRetrieve_EntityStatsFailureKeepsEntityResults(t *testing.T) {
+	entityHit := model.Memory{ID: uuid.New(), Content: "Biscuit trembles during thunderstorms", Type: model.MemoryTypeSemantic}
+	repo := &fakeRepo{
+		textResults:    []model.MemoryWithContext{memory("the deploy target is production")},
+		searchable:     true,
+		entityResults:  []model.Memory{entityHit},
+		memoryEntities: map[uuid.UUID][]string{entityHit.ID: {"biscuit"}},
+		entityStatsErr: errors.New("stats query timed out"),
+	}
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "What scares Biscuit?", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	for _, r := range results {
+		if r.Memory.ID == entityHit.ID {
+			return
+		}
+	}
+	t.Error("entity-only memory lost when mention stats failed: degradation must cost ordering quality, never results")
+}
+
+// The weights actually reorder: a memory matching only a ubiquitous entity
+// must score below one matching a rare entity, given otherwise equal evidence.
+//
+// This is the end-to-end face of the IDF change; the formula itself is pinned
+// in ranking. Ubiquity here: 90 of 100 memories mention "caroline", 3 mention
+// "biscuit". The query names the two entities apart from each other, because
+// the rule extractor deliberately reads "Caroline and Biscuit" as one entity
+// (the "War and Peace" rule), which would match neither.
+func TestRetrieve_RareEntityOutranksUbiquitousEntity(t *testing.T) {
+	carolineOnly := model.Memory{ID: uuid.New(), Content: "a generic note", Type: model.MemoryTypeSemantic}
+	biscuitHit := model.Memory{ID: uuid.New(), Content: "trembling during storms", Type: model.MemoryTypeSemantic}
+	repo := &fakeRepo{
+		searchable:    true,
+		entityResults: []model.Memory{carolineOnly, biscuitHit},
+		memoryEntities: map[uuid.UUID][]string{
+			carolineOnly.ID: {"caroline"},
+			biscuitHit.ID:   {"biscuit"},
+		},
+		entityStats: map[string]int64{"caroline": 90, "biscuit": 3},
+		entityTotal: 100,
+	}
+
+	results, err := New(repo, fixedEmbedder{}).Retrieve(context.Background(), "Why is Biscuit hiding from the storm near Caroline?", "proj", nil, 5)
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+
+	rank := map[uuid.UUID]int{}
+	for i, r := range results {
+		rank[r.Memory.ID] = i + 1
+	}
+	rb, okB := rank[biscuitHit.ID]
+	rc, okC := rank[carolineOnly.ID]
+	if !okB || !okC {
+		t.Fatalf("expected both entity candidates in results; got %d results", len(results))
+	}
+	if rb >= rc {
+		t.Errorf("rare-entity memory ranked %d, ubiquitous-entity memory ranked %d: "+
+			"discrimination weighting must order them the other way", rb, rc)
 	}
 }

--- a/internal/retrieval/retrieval.go
+++ b/internal/retrieval/retrieval.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"sort"
 	"strings"
 
@@ -34,7 +35,7 @@ import (
 
 // Repo is the slice of the graph repository the read path needs.
 //
-// Narrow on purpose: it names six operations out of the repository's several
+// Narrow on purpose: it names seven operations out of the repository's several
 // dozen, so a test can supply a fake without implementing a graph store, and a
 // reader can see the whole surface the read path touches.
 type Repo interface {
@@ -44,6 +45,7 @@ type Repo interface {
 	SearchByVector(ctx context.Context, embedding []float32, projectID string, topK int) ([]model.MemoryWithContext, error)
 	FindMemoriesByEntities(ctx context.Context, projectID string, names []string, limit int) ([]model.Memory, error)
 	GetMemoryEntities(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID][]string, error)
+	EntityMentionStats(ctx context.Context, projectID string, names []string) (map[string]int64, int64, error)
 }
 
 // Engine runs the read path against a repository and an optional embedder.
@@ -238,6 +240,47 @@ func (e *Engine) Retrieve(
 	// above, so retrieval quality drives the final order.
 	results = ranking.RankResults(results, int(filter.TopK))
 	return results, nil
+}
+
+// entityWeights turns per-entity mention counts into discrimination weights in
+// [0, 1], on a bounded log curve:
+//
+//	w(e) = ln(1 + N/df(e)) / ln(1 + N)
+//
+// where N is the project's memory count and df(e) how many of its memories
+// mention the entity. An entity in every memory scores ln(2)/ln(1+N) -- near
+// zero in any real project -- and one mentioned once scores 1. Entities the
+// stats do not cover are left out of the map, which EntityOverlap reads as
+// full weight: they cannot be matched anyway, so their only role is padding
+// the denominator, exactly as before weighting.
+//
+// On the ablation baseline corpus (2,537 memories) this weighs "caroline",
+// named by most memories of her conversations, at roughly a tenth of an
+// entity mentioned three times.
+//
+// Returns nil -- uniform weights, the unweighted behaviour -- when the stats
+// are unavailable or the project is too small for frequency to mean anything.
+func (e *Engine) entityWeights(ctx context.Context, projectID string, queryEntities []string) map[string]float64 {
+	counts, total, err := e.repo.EntityMentionStats(ctx, projectID, queryEntities)
+	if err != nil {
+		logging.FromContext(ctx).Warn("entity mention stats failed; entity matches are weighted uniformly",
+			slog.String("project_id", projectID),
+			slog.Any("error", err))
+		return nil
+	}
+	if total <= 1 || len(counts) == 0 {
+		return nil
+	}
+
+	denom := math.Log(1 + float64(total))
+	weights := make(map[string]float64, len(counts))
+	for name, df := range counts {
+		if df < 1 {
+			continue
+		}
+		weights[name] = math.Log(1+float64(total)/float64(df)) / denom
+	}
+	return weights
 }
 
 // entityCandidatePoolFactor and maxEntityCandidatePool size the entity
@@ -568,6 +611,17 @@ func (e *Engine) entityMatches(
 		return nil, nil
 	}
 
+	// How much each query entity is worth. An entity mentioned by most of the
+	// project's memories discriminates nothing -- the ablation baseline
+	// measured this signal, unweighted, hurting adversarial questions 6-to-1
+	// by pulling generic entity matches into questions whose right answer was
+	// no answer -- while a rarely mentioned entity nearly answers the query
+	// by itself.
+	//
+	// A failure degrades to uniform weights, which is the unweighted
+	// behaviour: worse ordering, never a lost result.
+	weights := e.entityWeights(ctx, projectID, queryEntities)
+
 	// Every candidate is scored, including the ones the other retrievers
 	// found, so the signal orders the whole set rather than only its own hits.
 	ids := make([]uuid.UUID, 0, len(matches))
@@ -597,7 +651,7 @@ func (e *Engine) entityMatches(
 
 	overlap := make(map[uuid.UUID]float64, len(ids))
 	for _, id := range ids {
-		if o := ranking.EntityOverlap(byMemory[id], queryEntities); o > 0 {
+		if o := ranking.EntityOverlap(byMemory[id], queryEntities, weights); o > 0 {
 			overlap[id] = o
 		}
 	}

--- a/test/golden/golden.json
+++ b/test/golden/golden.json
@@ -13,77 +13,408 @@
     "  paraphrase - asks for the same thing in different words",
     "  subject    - names a person or service that several memories mention"
   ],
-
   "corpus": [
-    { "label": "db-migration", "type": "semantic", "content": "The team migrated the primary datastore from MySQL to PostgreSQL 18 because they needed graph traversal support." },
-    { "label": "db-old", "type": "semantic", "content": "Before the migration the primary datastore was MySQL 8." },
-    { "label": "cache", "type": "semantic", "content": "Redis holds session tokens and is treated as a cache, never as a source of truth." },
-    { "label": "deploy-tool", "type": "semantic", "content": "Deployments go out through Helm charts on Kubernetes, never by hand." },
-    { "label": "ci-runner", "type": "semantic", "content": "CI runs on GitHub Actions, with a self-hosted runner for the integration suite." },
-    { "label": "priya-owns-billing", "type": "semantic", "content": "Priya owns the billing service and reviews every change to it." },
-    { "label": "marcus-owns-auth", "type": "semantic", "content": "Marcus owns the auth service and the API key rotation runbook." },
-    { "label": "yuki-oncall", "type": "procedural", "content": "Yuki takes the on-call pager on Wednesdays." },
-    { "label": "elena-timezone", "type": "semantic", "content": "Elena works from Lisbon, so meetings after 16:00 UTC do not suit her." },
-    { "label": "billing-k8s", "type": "semantic", "content": "The billing service runs on Kubernetes with three replicas behind an ingress." },
-    { "label": "billing-outage", "type": "episodic", "content": "On 3 March the billing service went down for 40 minutes after a bad migration locked the invoices table." },
-    { "label": "auth-latency", "type": "episodic", "content": "In February the auth service p99 latency doubled after the token cache was disabled." },
-    { "label": "postmortem-rule", "type": "procedural", "content": "Every incident longer than 30 minutes gets a written postmortem within two working days." },
-    { "label": "test-rule", "type": "procedural", "content": "Run the full test suite before pushing to main; the pre-push hook is not optional." },
-    { "label": "review-rule", "type": "procedural", "content": "Pull requests need one approval, and the author never merges their own work." },
-    { "label": "commit-style", "type": "procedural", "content": "Commit messages follow Conventional Commits, and the body explains why rather than what." },
-    { "label": "secrets-rule", "type": "semantic", "content": "Secrets live in the cluster's Secret objects; nothing sensitive is ever committed to the repository." },
-    { "label": "grafana", "type": "semantic", "content": "Grafana dashboards are provisioned from source, and nobody edits them in the UI." },
-    { "label": "backup-rule", "type": "procedural", "content": "Database backups run nightly, and a restore is rehearsed on the first Monday of each month." },
-    { "label": "chose-go", "type": "semantic", "content": "The team chose Go for the engine because a single static binary keeps container images small." },
-    { "label": "rejected-mongo", "type": "semantic", "content": "MongoDB was rejected during the datastore evaluation because the query patterns are relational." },
-    { "label": "priya-vim", "type": "semantic", "content": "Priya prefers Vim keybindings and short code review comments." },
-    { "label": "marcus-diagrams", "type": "semantic", "content": "Marcus asks for a sequence diagram before any change that crosses service boundaries." },
-    { "label": "standup", "type": "episodic", "content": "The daily standup moved to 09:30 UTC in January so Elena could attend." },
-    { "label": "invoice-schema", "type": "semantic", "content": "The invoices table is partitioned by month and holds nine years of history." },
-    { "label": "rate-limit", "type": "semantic", "content": "The public API is rate limited to 6000 requests per minute per key." },
-    { "label": "quarterly-goal", "type": "episodic", "content": "In April the team committed to cutting p99 query latency below 200 milliseconds." },
-    { "label": "will-ingest", "type": "semantic", "content": "The ingest pipeline and its backfill scripts are maintained by Will." },
-    { "label": "yuki-laptop", "type": "episodic", "content": "Yuki's laptop was replaced in May after the keyboard failed during an incident." }
+    {
+      "label": "db-migration",
+      "type": "semantic",
+      "content": "The team migrated the primary datastore from MySQL to PostgreSQL 18 because they needed graph traversal support."
+    },
+    {
+      "label": "db-old",
+      "type": "semantic",
+      "content": "Before the migration the primary datastore was MySQL 8."
+    },
+    {
+      "label": "cache",
+      "type": "semantic",
+      "content": "Redis holds session tokens and is treated as a cache, never as a source of truth."
+    },
+    {
+      "label": "deploy-tool",
+      "type": "semantic",
+      "content": "Deployments go out through Helm charts on Kubernetes, never by hand."
+    },
+    {
+      "label": "ci-runner",
+      "type": "semantic",
+      "content": "CI runs on GitHub Actions, with a self-hosted runner for the integration suite."
+    },
+    {
+      "label": "priya-owns-billing",
+      "type": "semantic",
+      "content": "Priya owns the billing service and reviews every change to it."
+    },
+    {
+      "label": "marcus-owns-auth",
+      "type": "semantic",
+      "content": "Marcus owns the auth service and the API key rotation runbook."
+    },
+    {
+      "label": "yuki-oncall",
+      "type": "procedural",
+      "content": "Yuki takes the on-call pager on Wednesdays."
+    },
+    {
+      "label": "elena-timezone",
+      "type": "semantic",
+      "content": "Elena works from Lisbon, so meetings after 16:00 UTC do not suit her."
+    },
+    {
+      "label": "billing-k8s",
+      "type": "semantic",
+      "content": "The billing service runs on Kubernetes with three replicas behind an ingress."
+    },
+    {
+      "label": "billing-outage",
+      "type": "episodic",
+      "content": "On 3 March the billing service went down for 40 minutes after a bad migration locked the invoices table."
+    },
+    {
+      "label": "auth-latency",
+      "type": "episodic",
+      "content": "In February the auth service p99 latency doubled after the token cache was disabled."
+    },
+    {
+      "label": "postmortem-rule",
+      "type": "procedural",
+      "content": "Every incident longer than 30 minutes gets a written postmortem within two working days."
+    },
+    {
+      "label": "test-rule",
+      "type": "procedural",
+      "content": "Run the full test suite before pushing to main; the pre-push hook is not optional."
+    },
+    {
+      "label": "review-rule",
+      "type": "procedural",
+      "content": "Pull requests need one approval, and the author never merges their own work."
+    },
+    {
+      "label": "commit-style",
+      "type": "procedural",
+      "content": "Commit messages follow Conventional Commits, and the body explains why rather than what."
+    },
+    {
+      "label": "secrets-rule",
+      "type": "semantic",
+      "content": "Secrets live in the cluster's Secret objects; nothing sensitive is ever committed to the repository."
+    },
+    {
+      "label": "grafana",
+      "type": "semantic",
+      "content": "Grafana dashboards are provisioned from source, and nobody edits them in the UI."
+    },
+    {
+      "label": "backup-rule",
+      "type": "procedural",
+      "content": "Database backups run nightly, and a restore is rehearsed on the first Monday of each month."
+    },
+    {
+      "label": "chose-go",
+      "type": "semantic",
+      "content": "The team chose Go for the engine because a single static binary keeps container images small."
+    },
+    {
+      "label": "rejected-mongo",
+      "type": "semantic",
+      "content": "MongoDB was rejected during the datastore evaluation because the query patterns are relational."
+    },
+    {
+      "label": "priya-vim",
+      "type": "semantic",
+      "content": "Priya prefers Vim keybindings and short code review comments."
+    },
+    {
+      "label": "marcus-diagrams",
+      "type": "semantic",
+      "content": "Marcus asks for a sequence diagram before any change that crosses service boundaries."
+    },
+    {
+      "label": "standup",
+      "type": "episodic",
+      "content": "The daily standup moved to 09:30 UTC in January so Elena could attend."
+    },
+    {
+      "label": "invoice-schema",
+      "type": "semantic",
+      "content": "The invoices table is partitioned by month and holds nine years of history."
+    },
+    {
+      "label": "rate-limit",
+      "type": "semantic",
+      "content": "The public API is rate limited to 6000 requests per minute per key."
+    },
+    {
+      "label": "quarterly-goal",
+      "type": "episodic",
+      "content": "In April the team committed to cutting p99 query latency below 200 milliseconds."
+    },
+    {
+      "label": "will-ingest",
+      "type": "semantic",
+      "content": "The ingest pipeline and its backfill scripts are maintained by Will."
+    },
+    {
+      "label": "yuki-laptop",
+      "type": "episodic",
+      "content": "Yuki's laptop was replaced in May after the keyboard failed during an incident."
+    },
+    {
+      "label": "priya-numbers",
+      "type": "semantic",
+      "content": "Priya reviewed the quarterly revenue numbers before the board meeting."
+    },
+    {
+      "label": "priya-standup",
+      "type": "episodic",
+      "content": "Priya joined the Tuesday standup late because of a dentist appointment."
+    },
+    {
+      "label": "priya-vendor",
+      "type": "semantic",
+      "content": "Priya approved the vendor contract for the new laptops."
+    },
+    {
+      "label": "priya-onboarding",
+      "type": "semantic",
+      "content": "Priya updated the onboarding doc after the reorg."
+    },
+    {
+      "label": "priya-offsite",
+      "type": "episodic",
+      "content": "Priya booked the spring team offsite in Lisbon."
+    },
+    {
+      "label": "priya-mentor",
+      "type": "semantic",
+      "content": "Priya mentors two junior engineers on the platform team."
+    },
+    {
+      "label": "vpn-steps",
+      "type": "procedural",
+      "content": "The onboarding doc lists the VPN setup steps: install the client, request a certificate, then join the corp profile."
+    },
+    {
+      "label": "kenji-bonsai",
+      "type": "semantic",
+      "content": "A small bonsai named Kenji sits on the platform team's shelf and gets watered on Fridays."
+    }
   ],
-
   "cases": [
-    { "group": "lexical", "query": "Which database did the team migrate to?", "expect": "db-migration" },
-    { "group": "lexical", "query": "What was the primary datastore before the migration?", "expect": "db-old" },
-    { "group": "lexical", "query": "What is Redis used for?", "expect": "cache" },
-    { "group": "lexical", "query": "How do deployments go out?", "expect": "deploy-tool" },
-    { "group": "lexical", "query": "Where does CI run?", "expect": "ci-runner" },
-    { "group": "lexical", "query": "What is the rate limit on the public API?", "expect": "rate-limit" },
-    { "group": "lexical", "query": "How is the invoices table organised?", "expect": "invoice-schema" },
-    { "group": "lexical", "query": "Why was MongoDB rejected?", "expect": "rejected-mongo" },
-    { "group": "lexical", "query": "When do database backups run?", "expect": "backup-rule" },
-    { "group": "lexical", "query": "What happened to the billing service on 3 March?", "expect": "billing-outage" },
-    { "group": "lexical", "query": "How are Grafana dashboards managed?", "expect": "grafana" },
-    { "group": "lexical", "query": "Why did the team choose Go for the engine?", "expect": "chose-go" },
-
-    { "group": "paraphrase", "query": "Which storage engine holds our data now?", "expect": "db-migration" },
-    { "group": "paraphrase", "query": "Can I keep the only copy of something in Redis?", "expect": "cache" },
-    { "group": "paraphrase", "query": "Is it acceptable to apply manifests to the cluster by hand?", "expect": "deploy-tool" },
-    { "group": "paraphrase", "query": "Does someone else have to look at my change before it lands?", "expect": "review-rule" },
-    { "group": "paraphrase", "query": "What write-up is required after a long incident?", "expect": "postmortem-rule" },
-    { "group": "paraphrase", "query": "Am I allowed to check an API token into the repository?", "expect": "secrets-rule" },
-    { "group": "paraphrase", "query": "What should I run before pushing to main?", "expect": "test-rule" },
-    { "group": "paraphrase", "query": "How should I word a commit message?", "expect": "commit-style" },
-    { "group": "paraphrase", "query": "Who is allowed to merge a pull request?", "expect": "review-rule" },
-    { "group": "paraphrase", "query": "What time does the team meet each morning?", "expect": "standup" },
-    { "group": "paraphrase", "query": "Who signs off on my work before it ships?", "expect": "review-rule" },
-    { "group": "paraphrase", "query": "Is there a written record after something breaks for a while?", "expect": "postmortem-rule" },
-    { "group": "paraphrase", "query": "How often is disaster recovery rehearsed?", "expect": "backup-rule" },
-
-    { "group": "subject", "query": "What does Priya own?", "expect": "priya-owns-billing" },
-    { "group": "subject", "query": "What are Priya's editor preferences?", "expect": "priya-vim" },
-    { "group": "subject", "query": "Who handles API key rotation?", "expect": "marcus-owns-auth" },
-    { "group": "subject", "query": "What does Marcus ask for before a cross-service change?", "expect": "marcus-diagrams" },
-    { "group": "subject", "query": "When is Yuki on call?", "expect": "yuki-oncall" },
-    { "group": "subject", "query": "Why can Elena not attend late meetings?", "expect": "elena-timezone" },
-    { "group": "subject", "query": "How many replicas does the billing service run?", "expect": "billing-k8s" },
-    { "group": "subject", "query": "What happened to the auth service in February?", "expect": "auth-latency" },
-    { "group": "subject", "query": "Why was Yuki's laptop replaced?", "expect": "yuki-laptop" },
-    { "group": "subject", "query": "What did the team commit to in April?", "expect": "quarterly-goal" },
-    { "group": "subject", "query": "What is Will responsible for?", "expect": "will-ingest" }
+    {
+      "group": "lexical",
+      "query": "Which database did the team migrate to?",
+      "expect": "db-migration"
+    },
+    {
+      "group": "lexical",
+      "query": "What was the primary datastore before the migration?",
+      "expect": "db-old"
+    },
+    {
+      "group": "lexical",
+      "query": "What is Redis used for?",
+      "expect": "cache"
+    },
+    {
+      "group": "lexical",
+      "query": "How do deployments go out?",
+      "expect": "deploy-tool"
+    },
+    {
+      "group": "lexical",
+      "query": "Where does CI run?",
+      "expect": "ci-runner"
+    },
+    {
+      "group": "lexical",
+      "query": "What is the rate limit on the public API?",
+      "expect": "rate-limit"
+    },
+    {
+      "group": "lexical",
+      "query": "How is the invoices table organised?",
+      "expect": "invoice-schema"
+    },
+    {
+      "group": "lexical",
+      "query": "Why was MongoDB rejected?",
+      "expect": "rejected-mongo"
+    },
+    {
+      "group": "lexical",
+      "query": "When do database backups run?",
+      "expect": "backup-rule"
+    },
+    {
+      "group": "lexical",
+      "query": "What happened to the billing service on 3 March?",
+      "expect": "billing-outage"
+    },
+    {
+      "group": "lexical",
+      "query": "How are Grafana dashboards managed?",
+      "expect": "grafana"
+    },
+    {
+      "group": "lexical",
+      "query": "Why did the team choose Go for the engine?",
+      "expect": "chose-go"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Which storage engine holds our data now?",
+      "expect": "db-migration"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Can I keep the only copy of something in Redis?",
+      "expect": "cache"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Is it acceptable to apply manifests to the cluster by hand?",
+      "expect": "deploy-tool"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Does someone else have to look at my change before it lands?",
+      "expect": "review-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "What write-up is required after a long incident?",
+      "expect": "postmortem-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Am I allowed to check an API token into the repository?",
+      "expect": "secrets-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "What should I run before pushing to main?",
+      "expect": "test-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "How should I word a commit message?",
+      "expect": "commit-style"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Who is allowed to merge a pull request?",
+      "expect": "review-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "What time does the team meet each morning?",
+      "expect": "standup"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Who signs off on my work before it ships?",
+      "expect": "review-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "Is there a written record after something breaks for a while?",
+      "expect": "postmortem-rule"
+    },
+    {
+      "group": "paraphrase",
+      "query": "How often is disaster recovery rehearsed?",
+      "expect": "backup-rule"
+    },
+    {
+      "group": "subject",
+      "query": "What does Priya own?",
+      "expect": "priya-owns-billing"
+    },
+    {
+      "group": "subject",
+      "query": "What are Priya's editor preferences?",
+      "expect": "priya-vim"
+    },
+    {
+      "group": "subject",
+      "query": "Who handles API key rotation?",
+      "expect": "marcus-owns-auth"
+    },
+    {
+      "group": "subject",
+      "query": "What does Marcus ask for before a cross-service change?",
+      "expect": "marcus-diagrams"
+    },
+    {
+      "group": "subject",
+      "query": "When is Yuki on call?",
+      "expect": "yuki-oncall"
+    },
+    {
+      "group": "subject",
+      "query": "Why can Elena not attend late meetings?",
+      "expect": "elena-timezone"
+    },
+    {
+      "group": "subject",
+      "query": "How many replicas does the billing service run?",
+      "expect": "billing-k8s"
+    },
+    {
+      "group": "subject",
+      "query": "What happened to the auth service in February?",
+      "expect": "auth-latency"
+    },
+    {
+      "group": "subject",
+      "query": "Why was Yuki's laptop replaced?",
+      "expect": "yuki-laptop"
+    },
+    {
+      "group": "subject",
+      "query": "What did the team commit to in April?",
+      "expect": "quarterly-goal"
+    },
+    {
+      "group": "subject",
+      "query": "What is Will responsible for?",
+      "expect": "will-ingest"
+    },
+    {
+      "group": "discrimination",
+      "query": "Following Priya's onboarding doc, how do I set up the VPN?",
+      "expect": "vpn-steps"
+    },
+    {
+      "group": "discrimination",
+      "query": "Who waters Kenji?",
+      "expect": "kenji-bonsai"
+    },
+    {
+      "group": "discrimination",
+      "query": "Which vendor contract did Priya approve?",
+      "expect": "priya-vendor"
+    },
+    {
+      "group": "discrimination",
+      "query": "Did Priya mention the billing outage?",
+      "expect": "billing-outage"
+    },
+    {
+      "group": "discrimination",
+      "query": "What does Priya think about Redis?",
+      "expect": "cache"
+    },
+    {
+      "group": "discrimination",
+      "query": "Has Priya seen the invoices table?",
+      "expect": "invoice-schema"
+    },
+    {
+      "group": "discrimination",
+      "query": "Did Priya set up the Grafana dashboards?",
+      "expect": "grafana"
+    }
   ]
 }

--- a/test/golden/golden_test.go
+++ b/test/golden/golden_test.go
@@ -120,12 +120,21 @@ type groupFloor struct {
 	recall, mrr float64
 }
 
-// Measured with the bag-of-words embedder over 36 cases: overall 0.917 / 0.856,
-// lexical 1.000 / 0.958, paraphrase 0.769 / 0.679, subject 1.000 / 0.955.
+// Measured with the bag-of-words embedder over 43 cases: overall 0.930 / 0.851,
+// lexical 1.000 / 0.958, paraphrase 0.769 / 0.679, subject 1.000 / 0.932,
+// discrimination 1.000 / 0.857.
 var offlineFloors = floors{
 	recall: 0.90, mrr: 0.83,
 	groups: []groupFloor{
 		{"lexical", 1.00, 0.90},
+		// One case carries the entity IDF weighting on its own, the same way
+		// "What is Will responsible for?" carries entity retrieval (see the
+		// file comment): "Did Priya mention the billing outage?" ranks 2 with
+		// discrimination weighting and 5 without, because the unweighted
+		// entity signal boosts every memory naming Priya equally. Audited by
+		// forcing entityWeights to nil: the group falls to MRR 0.814 and this
+		// floor trips.
+		{"discrimination", 1.00, 0.85},
 		// Three of thirteen miss entirely: those queries share almost no words
 		// with their answers, and a hashed bag-of-words embedder scores token
 		// overlap rather than meaning. This floor guards the fallback, not
@@ -135,9 +144,10 @@ var offlineFloors = floors{
 	},
 }
 
-// Measured with Ollama and nomic-embed-text at 768 dimensions, same 36 cases:
-// overall 0.944 / 0.889, lexical 1.000 / 1.000, paraphrase 0.846 / 0.731,
-// subject 1.000 / 0.955. Three consecutive runs, identical.
+// Measured with Ollama and nomic-embed-text at 768 dimensions, same 43 cases:
+// overall 0.953 / 0.884, paraphrase 0.846 / 0.731, discrimination identical to
+// the offline tier at 1.000 / 0.857 -- the guard case flips on entity
+// weighting, not on embedding quality.
 //
 // Tighter than offline on every axis, deliberately: a real embedder is
 // expected to do better, and a tier that accepted the offline numbers would
@@ -146,6 +156,7 @@ var onlineFloors = floors{
 	recall: 0.92, mrr: 0.86,
 	groups: []groupFloor{
 		{"lexical", 1.00, 0.95},
+		{"discrimination", 1.00, 0.85},
 		{"paraphrase", 0.84, 0.68},
 		{"subject", 1.00, 0.90},
 	},
@@ -169,7 +180,9 @@ func activeFloors() (floors, string) {
 //	lexical    - shares distinctive words with its answer
 //	paraphrase - asks for the same thing in different words
 //	subject    - names a person or service several memories mention
-var groupNames = []string{"lexical", "paraphrase", "subject"}
+//	discrimination - names a ubiquitous entity while the answer hangs on
+//	                 rarer evidence; guards the entity IDF weighting
+var groupNames = []string{"lexical", "paraphrase", "subject", "discrimination"}
 
 type goldenSet struct {
 	Corpus []struct {


### PR DESCRIPTION
The entity signal treated every shared entity as equal evidence, and the
ablation baseline measured what that costs: the signal reshaped a
quarter of every top-10 to zero net effect, and on adversarial
questions it hurt 6-to-1 by boosting every memory naming the question's
subject -- and the subject is named by most of a project's memories.
docs/research/ablation-baseline.md has the full arithmetic.

Each query entity now carries a weight on a bounded log curve,
ln(1 + N/df) / ln(1 + N): an entity mentioned by nearly every memory is
worth almost nothing, one mentioned a handful of times is worth almost
everything. On the baseline corpus that puts 'caroline' at roughly a
tenth of an entity mentioned three times. Weights come from one
project-scoped mention-count query; a failure there degrades to uniform
weights -- the old ordering, never a lost result -- and the golden suite
gains a discrimination group whose guard case was audited the same way
as the suite's other carriers: force uniform weights and the group
floor trips (MRR 0.857 to 0.814, rank 2 to rank 5).

Both directions are pinned in unit tests: a rare shared entity must
outweigh a ubiquitous one, and nil weights must reproduce the
unweighted arithmetic exactly.
