### PR TITLE
Make the report say which memory it actually used

### DIFF
--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -41,6 +41,20 @@ export KORA_API_KEY=$(grep '^KORA_API_KEYS' .env | cut -d= -f2 | tr -d '"' | cut
 **3. Rehearse both runs once.** Roughly 6 seconds each, so this is cheap.
 Confirm you get the numbers in the table below before recording, not during.
 
+**4. Check the `Memory:` line.** Every report states which memory it used, in
+its fourth line. Before a take, confirm it says what you expect:
+
+```
+Memory: Kora at localhost:18095                                  <- live, good
+Memory: no memory (KORA_URL / KORA_API_KEY not set)              <- the ladder-alone run
+Memory: Kora at localhost:18095 -- UNREACHABLE, ran without memory   <- BAD, stop
+```
+
+The third one is the trap this line exists to close: losing the engine is
+caught and logged rather than raised, so a degraded run otherwise prints a
+report that looks completely healthy, and the one-line warning has scrolled
+off the top by the time the report finishes.
+
 ## The demo, in two commands
 
 The contrast is the point. Run the same command twice, once with the engine
@@ -100,6 +114,9 @@ make eval
 
 ## If something goes wrong on camera
 
+- **The `Memory:` line says UNREACHABLE.** The run was not backed by memory,
+  whatever the rest of the report says. Stop the take. The engine is down or
+  `KORA_URL` points somewhere wrong; check it is 18095 and not 8080.
 - **Report shows 0 promises and far fewer contacts than the table.** The
   engine is up but the agent is not reaching it. Check `KORA_URL` points at
   18095 and not 8080.

--- a/examples/receivables-chaser/chaser/cli.py
+++ b/examples/receivables-chaser/chaser/cli.py
@@ -98,7 +98,9 @@ def _run(args: argparse.Namespace) -> int:
 
     start_date = razorpay.today()
     end_date = start_date + timedelta(days=days - 1)
-    data = report.build_report(result, args.merchant, start_date, end_date)
+    data = report.build_report(
+        result, args.merchant, start_date, end_date, memory_status=memory.status(),
+    )
 
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/examples/receivables-chaser/chaser/memory.py
+++ b/examples/receivables-chaser/chaser/memory.py
@@ -32,6 +32,16 @@ class Memory(Protocol):
 
     def recall(self, project_id: str, query: str, top_k: int = 50) -> list[str]: ...
 
+    def status(self) -> str:
+        """One line naming the backend actually in use, for the report.
+
+        Every way of losing Kora at runtime is caught and logged rather than
+        raised, so a degraded run prints a report that looks entirely normal.
+        Asking the memory to describe itself lets the report carry that fact
+        instead of leaving it in a warning that has scrolled away.
+        """
+        ...
+
 
 class KoraMemory:
     """Wraps the Kora SDK client.
@@ -68,6 +78,9 @@ class KoraMemory:
         results = self._client(project_id).query(query, top_k=top_k)
         return [r.memory.content for r in results]
 
+    def status(self) -> str:
+        return f"Kora at {self._endpoint}"
+
 
 class NullMemory:
     """Used when no Kora endpoint is configured at all.
@@ -88,6 +101,9 @@ class NullMemory:
             logger.warning("no Kora configured; %s is running without memory", project_id)
             self._warned.add(project_id)
         return []
+
+    def status(self) -> str:
+        return "no memory (KORA_URL / KORA_API_KEY not set)"
 
 
 class SafeMemory:
@@ -119,3 +135,11 @@ class SafeMemory:
         if not self._warned:
             logger.warning("Kora unreachable (%s); continuing without memory", exc)
             self._warned = True
+
+    def status(self) -> str:
+        # A failure part-way through still means the run was not backed by
+        # memory for its whole length, so say so rather than reporting the
+        # endpoint it started out talking to.
+        if self._warned:
+            return f"{self._inner.status()} -- UNREACHABLE, ran without memory"
+        return self._inner.status()

--- a/examples/receivables-chaser/chaser/report.py
+++ b/examples/receivables-chaser/chaser/report.py
@@ -19,7 +19,13 @@ def _inr(amount: int) -> str:
     return f"₹{amount:,}"
 
 
-def build_report(result: RunResult, merchant: str, start_date: date, end_date: date) -> dict[str, Any]:
+def build_report(
+    result: RunResult,
+    merchant: str,
+    start_date: date,
+    end_date: date,
+    memory_status: str = "unknown",
+) -> dict[str, Any]:
     initial = result.initial_invoices
     final = result.final_invoices
 
@@ -72,6 +78,7 @@ def build_report(result: RunResult, merchant: str, start_date: date, end_date: d
         "start_date": start_date.isoformat(),
         "end_date": end_date.isoformat(),
         "invoices_processed": len(final),
+        "memory": memory_status,
         "contacts_by_rung": contacts_by_rung,
         "amount_outstanding_start": outstanding_start,
         "amount_recovered": total_recovered,
@@ -105,6 +112,11 @@ def render_markdown(data: dict[str, Any]) -> str:
         f"# Receivables Chaser Report -- {data['merchant']}",
         "",
         f"Run: {data['start_date']} to {data['end_date']} ({data['invoices_processed']} invoices)",
+        # Stated in the header: which memory was actually in the loop.
+        # Losing Kora mid-run is caught and logged rather than raised, so
+        # without this the report of a degraded run is indistinguishable
+        # from a healthy one once the warning has scrolled away.
+        f"Memory: {data.get('memory', 'unknown')}",
         "",
         "## Contacts sent",
         "",

--- a/examples/receivables-chaser/tests/conftest.py
+++ b/examples/receivables-chaser/tests/conftest.py
@@ -29,6 +29,9 @@ class FakeMemory:
     def recall(self, project_id: str, query: str, top_k: int = 50) -> list[str]:
         return list(self.store.get(project_id, []))[-top_k:]
 
+    def status(self) -> str:
+        return "fake in-memory Kora"
+
 
 class RankingFakeMemory:
     """A Kora stand-in that ranks and truncates the way the real engine does.
@@ -70,6 +73,9 @@ class RankingFakeMemory:
             key=lambda pair: (-self._score(query, pair[1]), -pair[0]),
         )
         return [content for _, content in ranked[:top_k]]
+
+    def status(self) -> str:
+        return "ranking fake in-memory Kora"
 
 
 @pytest.fixture

--- a/examples/receivables-chaser/tests/test_agent_live_memory.py
+++ b/examples/receivables-chaser/tests/test_agent_live_memory.py
@@ -197,3 +197,49 @@ def test_live_runs_keep_their_history(monkeypatch) -> None:
         f"a live run was namespaced to {seen['merchant']!r}; it would forget "
         "every previous day and re-chase customers who already promised"
     )
+
+
+def test_the_report_says_which_memory_it_used(tmp_path, monkeypatch, capsys) -> None:
+    """The report must state whether Kora was actually in the loop.
+
+    Every failure that disconnects the agent from Kora -- engine down, wrong
+    port, expired key -- is caught by SafeMemory and logged as a warning, then
+    the run continues on the escalation ladder and prints a report that looks
+    completely normal. The warning is one line at the top of ~64 lines of
+    output, so on a scrolled terminal the visible end of a degraded run is
+    indistinguishable from a healthy one.
+
+    That is a bad way to find out you recorded the wrong take, so the report
+    states its own memory backend and the number it should be compared
+    against.
+    """
+    from chaser import cli
+
+    argv = [
+        "run", "--recorded", "--days", "21",
+        "--world", str(WORLD), "--out-dir", str(tmp_path),
+    ]
+
+    monkeypatch.delenv("KORA_URL", raising=False)
+    monkeypatch.delenv("KORA_API_KEY", raising=False)
+    assert cli.main(argv) == 0
+    without = capsys.readouterr().out
+
+    assert "Memory" in without, "the report does not say what memory it used"
+    assert "no memory" in without.lower(), (
+        "a run with no Kora configured does not say so in its report"
+    )
+
+    # The dangerous case is not an unconfigured run but a configured one that
+    # cannot reach the engine: it is caught, logged, and then reports normally.
+    from chaser.memory import KoraMemory, SafeMemory
+
+    unreachable = SafeMemory(KoraMemory("http://localhost:1", "irrelevant"))
+    monkeypatch.setattr(cli, "_build_memory", lambda args: unreachable)
+    assert cli.main(argv) == 0
+    degraded = capsys.readouterr().out
+
+    assert "UNREACHABLE" in degraded, (
+        "a run that lost its connection to Kora printed a report that does "
+        "not say so; it is indistinguishable from a healthy run"
+    )


### PR DESCRIPTION
## The problem

Every way of losing Kora at runtime -- engine down, wrong port, expired key, a blip mid-run -- is caught by `SafeMemory`, logged as a single warning, and then the run continues on the escalation ladder alone and prints a report that looks entirely normal.

That warning is line 3 of roughly 64 lines of output. By the time the report finishes it has scrolled off, so the visible end of a degraded run is indistinguishable from a healthy one. Measured on the demo itself: a run against a dead port still prints `Recovered 633,300` and a full exception table.

That is a bad way to find out you recorded the wrong take for a demo video, and a worse way to find out a production cron has been running without memory for a week.

## The change

Each `Memory` implementation now describes itself, and the report carries that on line 4:

```
Memory: Kora at localhost:18095
Memory: no memory (KORA_URL / KORA_API_KEY not set)
Memory: Kora at localhost:18095 -- UNREACHABLE, ran without memory
```

Putting `status()` on the implementations rather than deriving it in the CLI means it cannot drift from what was really in the loop. `SafeMemory` reports the degraded form if it ever swallowed a failure, because a run that lost the engine part-way through was not memory-backed for its whole length.

`report.json` gains a `memory` field alongside the rendered header.

## Verification

- All three states exercised end to end against a live engine (18095), a dead port, and no configuration; each printed the expected line.
- New test covers the unconfigured and unreachable cases, and was confirmed to fail with the header line removed.
- 46/46 example tests pass. `scripts/verify_docs.sh` passes.
- `docs/RECORDING.md` gains a pre-take check for this line and a "stop the take" entry in its failure table.
