### PR TITLE
Wait on the rollout, not on pods that may not exist yet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -367,8 +367,29 @@ jobs:
             --set postgres.password="$E2E_PG_PASSWORD" \
             --set auth.apiKeys="$E2E_API_KEY"
 
-          kubectl -n kora wait --for=condition=ready pod -l app=postgres-age --timeout=120s
-          kubectl -n kora wait --for=condition=ready pod -l app=kora-api --timeout=120s
+          # `helm install` returns once the API server has accepted the
+          # manifests, not once the controllers have created anything. So a
+          # `kubectl wait` for a pod condition can arrive while the label
+          # selector still matches nothing, and `wait` treats "no such object"
+          # as an error rather than something to wait for:
+          #
+          #   error: no matching resources found
+          #
+          # That is a race, not a deployment failure, and it fails the most
+          # expensive job in CI several minutes in. Observed on a docs-only
+          # change that could not have affected the deployment, which reran
+          # green with no edits.
+          #
+          # `rollout status` is the right instrument: it waits on the
+          # StatefulSet and Deployment themselves, which exist the moment helm
+          # returns, and it only reports success once the desired replicas are
+          # actually ready. The pod-level waits stay as a cheap assertion that
+          # what became ready is what we asked for.
+          kubectl -n kora rollout status statefulset/postgres-age --timeout=180s
+          kubectl -n kora rollout status deployment/kora-api --timeout=180s
+
+          kubectl -n kora wait --for=condition=ready pod -l app=postgres-age --timeout=60s
+          kubectl -n kora wait --for=condition=ready pod -l app=kora-api --timeout=60s
 
       - name: Port forward
         run: |


### PR DESCRIPTION
## The failure

The E2E job failed on a **documentation-only** change (PR #102, three markdown files) with:

```
error: no matching resources found
```

## Why

`helm install` returns once the API server has accepted the manifests, not once the controllers have created anything from them. The `kubectl wait --for=condition=ready pod -l app=...` that followed could therefore arrive while its label selector still matched nothing, and `wait` treats "no such object" as an error rather than as something to wait for.

So it is a race, and it fails the most expensive job in CI (roughly 8 minutes, kind cluster + chart install) several minutes in, on changes that cannot possibly have caused it.

Confirmed by rerunning the identical commit with no edits: green.

## The fix

`rollout status` waits on the StatefulSet and Deployment themselves, which exist as soon as helm returns, and reports success only once the desired replicas are ready. The existing pod-level waits stay, with shorter timeouts, as a cheap assertion that what became ready is what we asked for.

Resource names were read out of `helm template` rather than guessed, which caught one: the StatefulSet is `postgres-age`, not `kora-postgres`. Label selectors verified against the rendered chart too.

## Verification

The real check is the E2E job on this PR going green. YAML parses and the names match the chart; the race itself is timing-dependent, so no local reproduction is possible.
