### PR TITLE
Document the two metrics the engine exports and the table omitted

### DIFF
--- a/site/public/docs/operations.md
+++ b/site/public/docs/operations.md
@@ -64,6 +64,8 @@ Prometheus metrics are on `/metrics`, on the HTTP port, requiring no API key. Na
 | `kora_active_sessions` | gauge | Sessions currently open |
 | `kora_pool_connections` | gauge | Connection pool state |
 | `kora_pool_acquire_wait_seconds_total` | counter | Time spent waiting for a connection |
+| `kora_memories_consolidated_total` | counter | Extracted memories folded into an existing memory rather than stored, labelled by subsumption verdict |
+| `kora_extraction_fallbacks_total` | counter | Conversations the rule-based extractor answered because the LLM extractor failed or missed content, labelled by reason |
 
 The histogram buckets are custom rather than `prometheus.DefBuckets`, which starts at 5ms and jumps 0.1 to 0.25 to 0.5 to 1s. A store costs about 4ms here, so the default buckets put nearly every observation in the first one and make percentiles meaningless.
 


### PR DESCRIPTION
## The failure

`main` is currently red on the site's docs check, and has been since these two counters were added:

```
kora_memories_consolidated_total is exported but missing from the docs metrics table
kora_extraction_fallbacks_total is exported but missing from the docs metrics table
```

It surfaced on Dependabot PR #94, which made it look like a dependency problem. It is not: I reproduced it on clean `main` with no changes.

## Why it matters

This is `check-docs.mjs` working exactly as designed. `operations.md` lists every `kora_*` metric by name, and that list rots invisibly: a metric added in Go is simply absent from it, and an operator only discovers the gap when their dashboard query returns nothing.

## The fix

Both rows added, with descriptions taken from the `Help` strings in `internal/metrics/metrics.go` so the documented meaning and the exported meaning have a single source.

## Verification

- Reproduced the failure on clean `main` first
- `node scripts/check-docs.mjs` now passes: `docs: 13 pages, docsify 5.0.0, all links resolve`
- Full `pnpm check` passes: build, prerender, links, palette/WCAG, accessibility, cross-browser (WebKit + Firefox), and waitlist
