### PR TITLE
docs: add agent integration and Razorpay guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ kora/
 
 | | |
 |---|---|
+| [Agent integration](site/public/docs/agent-integration.md) | How to add Kora to MCP, Python, and REST-based agents |
+| [Razorpay agent tutorial](site/public/docs/razorpay-agent.md) | Build and run the receivables agent in recorded or Razorpay test mode |
 | [docs/ARCHITECTURE_DECISIONS.md](docs/ARCHITECTURE_DECISIONS.md) | Why one Postgres, why Go, why rules over an LLM, why gRPC plus REST, and what breaks at 10M nodes |
 | [docs/OPTIMIZATION_REPORT.md](docs/OPTIMIZATION_REPORT.md) | The full technical report: baseline vs final, ablations, failure analysis, papers used and rejected |
 | [docs/WORKLOG.md](docs/WORKLOG.md) | Every hypothesis, measurement and revert, in order |

--- a/site/public/docs/README.md
+++ b/site/public/docs/README.md
@@ -23,6 +23,8 @@ Most memory layers are a vector database with a system prompt in front. That get
 | See it working in about five minutes | [Quick start](quickstart.md) |
 | Run it properly, on Kubernetes | [Installation](installation.md) |
 | Understand memories, edges, and superseding | [Concepts](concepts.md) |
+| Add long-term memory to an agent | [Agent integration](agent-integration.md) |
+| Study a complete Razorpay agent | [Razorpay agent](razorpay-agent.md) |
 | Call it from your own code | [API reference](api.md), [SDKs and CLI](clients.md) |
 | Know how it works inside | [Architecture](architecture.md) |
 | Operate it: tuning, metrics, backups | [Configuration](configuration.md), [Operations](operations.md) |

--- a/site/public/docs/_sidebar.md
+++ b/site/public/docs/_sidebar.md
@@ -9,6 +9,8 @@
 
 - **Using kora**
 - [Concepts](concepts.md)
+- [Agent integration](agent-integration.md)
+- [Razorpay agent](razorpay-agent.md)
 - [API reference](api.md)
 - [SDKs and CLI](clients.md)
 

--- a/site/public/docs/agent-integration.md
+++ b/site/public/docs/agent-integration.md
@@ -1,0 +1,217 @@
+# Integrate Kora with an agent
+
+Kora sits beside an agent as its long-term memory.
+The agent remains responsible for deciding what to do, while Kora stores what happened and retrieves the history that matters to the next decision.
+
+The useful integration is a loop:
+
+```text
+start a run -> recall relevant memory -> decide and act -> store the outcome
+```
+
+Use the MCP server when the agent already supports MCP.
+Use the Python SDK inside a Python application.
+Use the REST API from any other language or runtime.
+
+## 1. Choose the project boundary
+
+Every store and query belongs to a Kora project.
+Queries never cross projects, but a project is an organisation boundary rather than an authorization boundary.
+Every API key in one Kora deployment can read every project in that deployment.
+
+Choose the narrowest scope whose memories are normally recalled together.
+
+| Agent | A useful project ID |
+| --- | --- |
+| Personal assistant | `assistant-user-<user-id>` |
+| Support agent | `support-account-<account-id>` |
+| Coding agent | `code-<repository-id>` |
+| Receivables agent | `receivables-<merchant-id>-<customer-id>` |
+
+Do not put unrelated users or customers into one large project and rely on `top_k` to separate them.
+Relevant memories can be pushed out of the returned window by another subject's history.
+
+If different customers must be security-isolated, give them separate Kora deployments or enforce that boundary in a trusted gateway.
+See [Concepts](concepts.md) for the distinction between a deployment and a project.
+
+## 2. Recall before deciding
+
+Ask for the history needed by the current decision, not for every memory in the project.
+
+```python
+from kora import KoraClient
+
+memory = KoraClient(
+    endpoint="localhost:50051",
+    api_key="ctx0_...",
+    project="support-account-acme",
+)
+
+results = memory.query(
+    "What has this account reported about duplicate charges?",
+    top_k=8,
+)
+
+context = [result.memory.content for result in results]
+```
+
+Give `context` to the policy or model that makes the next decision.
+Keep source-system facts in their source system: an invoice's paid status belongs in the payment provider, while a customer's promise to pay belongs in Kora.
+
+Each query result also includes a score and relationship context.
+Use those fields when the agent needs to explain why a memory was recalled.
+
+## 3. Store outcomes after acting
+
+Write concise statements that will make sense when read without the current prompt.
+Include stable identifiers and dates when the memory describes an event.
+
+```python
+memory.store(
+    "On 2026-09-05, Acme disputed invoice inv_42 because the amount was incorrect.",
+    type="episodic",
+    tags=["invoice", "dispute", "inv_42"],
+)
+```
+
+Use the three memory types deliberately:
+
+| Type | Store it for |
+| --- | --- |
+| `episodic` | Something that happened, with a date or run context |
+| `semantic` | A stable fact or current state |
+| `procedural` | How the agent or organisation normally works |
+
+For conversational agents, send the transcript to `POST /v1/memories/extract` after the exchange instead of inventing a separate extraction prompt.
+Kora can then create memories and relationships, including a `SUPERSEDES` edge when new information replaces an older belief.
+
+## 4. Group work into sessions
+
+Sessions are optional, but they make it possible to trace memories to one continuous agent run.
+
+```python
+with memory.session(agent_id="support-agent") as session:
+    memory.store(
+        "Reviewed duplicate-charge report for ticket tkt_19.",
+        type="episodic",
+        session_id=session.id,
+    )
+```
+
+Start one session per conversation, job, or scheduled run.
+Do not use a session as the long-term memory boundary; the project provides that boundary.
+
+## Connect an MCP agent
+
+Clone Kora and install its MCP server into the Python environment used by the agent:
+
+```bash
+pip install ./mcp-server
+```
+
+Add this server to the agent's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "kora": {
+      "command": "kora-mcp",
+      "env": {
+        "KORA_HTTP_URL": "http://localhost:8080",
+        "KORA_API_KEY": "<your generated key>",
+        "KORA_PROJECT": "code-my-repository"
+      }
+    }
+  }
+}
+```
+
+The exact location of this JSON depends on the agent, but the server definition is the same for Claude Code, Cursor, Windsurf, Cline, and other stdio MCP clients.
+The server exposes `memory_store`, `memory_query`, `memory_extract`, `memory_profile`, `memory_connect`, `memory_delete`, and `memory_graph`.
+
+Tell the agent when to use them in its standing instructions:
+
+```text
+At the start of a task, query Kora for decisions and procedures relevant to the request.
+Before changing an established design, query for earlier decisions about that component.
+After completing the task, store durable decisions and user preferences, not transient logs or secrets.
+Never store credentials, access tokens, private keys, or raw environment files.
+```
+
+Run `kora-mcp --transport http --port 8000` only when the client requires a remote HTTP transport.
+Protect that endpoint as carefully as the Kora API because its tools can read and change memory.
+
+## Connect a Python agent
+
+The Python package is currently installed from the repository because it has not been published to PyPI:
+
+```bash
+pip install ./sdk/python
+```
+
+Hide Kora behind a small interface owned by the agent:
+
+```python
+from typing import Protocol
+
+from kora import KoraClient
+
+
+class AgentMemory(Protocol):
+    def recall(self, question: str) -> list[str]: ...
+    def remember(self, statement: str, type: str = "episodic") -> None: ...
+
+
+class KoraMemory:
+    def __init__(self, endpoint: str, api_key: str, project: str) -> None:
+        self.client = KoraClient(endpoint=endpoint, api_key=api_key, project=project)
+
+    def recall(self, question: str) -> list[str]:
+        return [result.memory.content for result in self.client.query(question, top_k=10)]
+
+    def remember(self, statement: str, type: str = "episodic") -> None:
+        self.client.store(statement, type=type)
+```
+
+This keeps the decision loop independent of Kora's transport and makes degraded behavior explicit.
+Decide whether a memory outage should stop the action, retry it, or continue without memory based on the risk of the agent's job.
+A customer-contact agent should normally fail closed or hand off when it cannot prove that the customer was not already contacted.
+
+## Connect any other agent
+
+The REST gateway accepts JSON and an `X-API-Key` header.
+An integration only needs two calls to begin:
+
+```bash
+curl "http://localhost:8080/v1/memories/query?query=customer+payment+history&project_id=receivables-acme-cust_42&top_k=10" \
+  -H "X-API-Key: $KORA_API_KEY"
+
+curl -X POST http://localhost:8080/v1/memories \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $KORA_API_KEY" \
+  -d '{
+    "content": "On 2026-09-05, customer cust_42 promised to pay invoice inv_42 by 2026-09-10.",
+    "type": 1,
+    "project_id": "receivables-acme-cust_42",
+    "tags": ["promise", "inv_42"]
+  }'
+```
+
+See the [API reference](api.md) for extraction, profiles, graph context, and sessions.
+
+## Production checklist
+
+- Query before the action whose safety depends on memory.
+- Store the observed outcome after the action succeeds.
+- Use stable project IDs and keep unrelated subjects in separate projects.
+- Keep authoritative business state in its source system.
+- Put dates and source identifiers into episodic memories.
+- Set timeouts and choose an explicit failure policy.
+- Do not store secrets or entire payloads when a compact durable statement is enough.
+- Check `/v1/health` at startup and monitor request failures and latency.
+- Use the self-hosted quality profile when semantic recall matters beyond exact word overlap.
+
+## See a complete agent
+
+The [Razorpay receivables agent](razorpay-agent.md) applies this loop to overdue invoices and includes a deterministic offline simulation, an audit trail, and a live Razorpay test-mode adapter.
+

--- a/site/public/docs/clients.md
+++ b/site/public/docs/clients.md
@@ -5,8 +5,10 @@ Two clients ship with kora: a Python SDK and a Go CLI. Both are thin wrappers ov
 ## Python SDK
 
 ```bash
-pip install kora
+pip install ./sdk/python
 ```
+
+The package is currently installed from a Kora clone because it has not been published to PyPI.
 
 ```python
 from kora import KoraClient
@@ -147,5 +149,7 @@ There is no JavaScript or Go client library yet. The REST API is plain JSON over
 
 ## Next
 
+- [Agent integration](agent-integration.md) - where to call these clients in an agent lifecycle
+- [Razorpay agent](razorpay-agent.md) - a complete application using the Python client
 - [API reference](api.md) - the endpoints underneath these clients
 - [Configuration](configuration.md) - what the server reads from the environment

--- a/site/public/docs/operations.md
+++ b/site/public/docs/operations.md
@@ -65,6 +65,7 @@ Prometheus metrics are on `/metrics`, on the HTTP port, requiring no API key. Na
 | `kora_pool_connections` | gauge | Connection pool state |
 | `kora_pool_acquire_wait_seconds_total` | counter | Time spent waiting for a connection |
 | `kora_memories_consolidated_total` | counter | Extracted memories folded into an existing memory rather than stored, labelled by subsumption verdict |
+| `kora_superseded_demotions_total` | counter | Retrieval candidates demoted because a live memory supersedes them |
 | `kora_extraction_fallbacks_total` | counter | Conversations the rule-based extractor answered because the LLM extractor failed or missed content, labelled by reason |
 
 The histogram buckets are custom rather than `prometheus.DefBuckets`, which starts at 5ms and jumps 0.1 to 0.25 to 0.5 to 1s. A store costs about 4ms here, so the default buckets put nearly every observation in the first one and make percentiles meaningless.

--- a/site/public/docs/quickstart.md
+++ b/site/public/docs/quickstart.md
@@ -106,6 +106,8 @@ A profile is the aggregate view: the static half is stable facts and preferences
 
 ## Next
 
+- [Agent integration](agent-integration.md) - where recall and store belong in an agent loop
+- [Razorpay agent](razorpay-agent.md) - a complete, measurable agent built on Kora
 - [Concepts](concepts.md) - what the types and edges mean, and why superseding matters
 - [Clients](clients.md) - the Python SDK and the CLI, instead of curl
 - [Installation](installation.md) - Helm, kind, and a deployment that survives a restart

--- a/site/public/docs/razorpay-agent.md
+++ b/site/public/docs/razorpay-agent.md
@@ -1,0 +1,183 @@
+# Build a Razorpay receivables agent
+
+Kora includes a complete sample agent that follows up on overdue Razorpay invoices.
+It recalls each customer's payment history before deciding whether to remind them, wait for a promise, offer a payment link, or hand the case to a human.
+
+The source is in [`examples/receivables-chaser`](https://github.com/NarayanaSabari/Kora/tree/main/examples/receivables-chaser).
+
+## What this example proves
+
+The same deterministic policy runs with and without Kora against a committed 21-day workload.
+Both configurations recover ₹633,300, but the memory-backed agent sends 49 messages instead of 216.
+
+| Configuration | Recovered | Messages sent |
+| --- | ---: | ---: |
+| Escalation ladder alone | ₹633,300 | 216 |
+| With Kora memory | ₹633,300 | 49 |
+
+Kora does not choose the collection action and a language model does not control it.
+The policy makes decisions from invoice state and recalled history.
+An optional model can only reword the selected message and cannot change its facts or action.
+
+## Architecture
+
+```text
+Razorpay invoice state -----+
+                            |
+Kora customer history ------+--> deterministic policy --> contact or handoff
+                            |                                 |
+date and contact limits ----+                                 +--> audit.jsonl
+                                                              +--> Kora outcome memory
+```
+
+The boundary is deliberate:
+
+| System | Owns |
+| --- | --- |
+| Razorpay | Invoice amount, due date, and paid status |
+| Kora | Contacts, promises, disputes, and escalations |
+| Policy | Whether to skip, remind, offer a link, or hand off |
+| Audit log | The rule and reason used for every decision |
+
+The agent never keeps a separate payment ledger, and Kora is not treated as the source of truth for whether money arrived.
+
+## Run the recorded agent first
+
+Recorded mode needs no credentials, network, model, or running Kora.
+It replays 50 invoices across 20 scripted customers and writes `audit.jsonl` and `report.json`.
+
+```bash
+git clone https://github.com/NarayanaSabari/Kora.git
+cd Kora/examples/receivables-chaser
+env -u KORA_URL -u KORA_API_KEY python3 -m chaser run --recorded --days 21
+```
+
+This first run uses `NullMemory`, so it shows the 216-message escalation-ladder baseline.
+
+## Run the same agent with Kora
+
+From the repository root, generate local credentials and start Kora:
+
+```bash
+cd ../..
+
+cat > .env <<EOF
+POSTGRES_PASSWORD=$(openssl rand -hex 16)
+KORA_API_KEYS=$(go run ./cmd/cli keys generate)
+EOF
+
+docker compose up -d
+export KORA_API_KEY=$(grep KORA_API_KEYS .env | cut -d= -f2)
+```
+
+Run the identical workload with memory enabled:
+
+```bash
+cd examples/receivables-chaser
+KORA_URL=http://localhost:8080 \
+KORA_API_KEY="$KORA_API_KEY" \
+  python3 -m chaser run --recorded --days 21
+```
+
+The report should identify the memory backend as Kora and show 49 messages sent.
+Each recorded run gets a fresh project namespace so a replay does not inherit contacts from an earlier replay.
+Pass `--resume` when you deliberately want the next recorded run to recall the previous one.
+
+## How Kora changes a decision
+
+Before evaluating a customer's invoices, the agent recalls payment-related history:
+
+```python
+project_id = f"receivables-{merchant}-{customer_id}"
+query = f"customer {customer.name} invoice payment promise dispute contact"
+memories = memory.recall(project_id, query, top_k=50)
+customer_facts = parse_facts(memories)
+```
+
+The project is scoped to one merchant and one customer.
+This prevents one customer's notes from crowding another customer's promise or dispute out of a ranked result set.
+
+The policy then applies its rules in order:
+
+1. Skip paid invoices.
+2. Hand unresolved disputes to a human and stop contacting the customer.
+3. Stop after a human escalation.
+4. Wait for a future promise-to-pay date.
+5. Increase the reminder level after a broken promise.
+6. Choose a reminder level from the number of days overdue.
+7. Escalate after three contacts with no response.
+8. Enforce invoice and customer contact limits.
+
+After an action succeeds, the agent writes an explicit event back to Kora:
+
+```text
+On 2026-09-05, sent a firm reminder to Acme for invoice inv_42 (₹18,500, 12 days overdue).
+On 2026-09-05, Acme promised to pay invoice inv_42 by 2026-09-10.
+```
+
+Those statements contain the date, customer, invoice, action, and amount needed by a later run.
+The next decision is therefore based on durable memory rather than process-local state.
+
+## Inspect the evidence
+
+`audit.jsonl` contains one record per invoice decision, including the policy rung, reason, overdue days, and whether a contact was sent.
+`report.json` is the structured source of truth for totals.
+
+```bash
+python3 -c "import json; d=json.load(open('report.json')); print(sum(d['contacts_by_rung'].values()), d['amount_recovered'])"
+```
+
+The recorded workload is generated from a fixed seed and uses dates from the fixture rather than the wall clock.
+The test suite pins the fixture digest and checks that repeated runs produce byte-identical audit logs.
+
+```bash
+python3 -m pytest
+```
+
+## Run against Razorpay test mode
+
+Copy the example environment template and fill in test-mode credentials locally:
+
+```bash
+cd examples/receivables-chaser
+cp .env.example .env
+```
+
+Do not commit this file.
+It contains the following integration settings:
+
+```dotenv
+KORA_URL=http://localhost:8080
+KORA_API_KEY=
+RAZORPAY_KEY_ID=
+RAZORPAY_KEY_SECRET=
+```
+
+Load the values and run one daily tick:
+
+```bash
+set -a && source .env && set +a
+python3 -m chaser run --live --merchant your-merchant-id
+```
+
+Live mode lists `issued` and `partially_paid` invoices, fetches their customers, and uses Razorpay's invoice email notification endpoint when the policy selects a reminder.
+It preserves the merchant project names across daily runs so yesterday's contacts remain visible today.
+
+The live adapter has an important limit: its invoice reads are exercised, but there is no Razorpay test account in this project's automated environment to verify the notification write end to end.
+Razorpay's notification endpoint also uses Razorpay's template rather than the agent's drafted custom message.
+A real customer reply arrives asynchronously, so production use still needs a webhook or support-system adapter that writes promises and disputes into Kora.
+
+## Turn the sample into a production agent
+
+Keep the example's core boundaries, then replace its demo edges:
+
+- Schedule `python3 -m chaser run --live` once per day with one stable `--merchant` value.
+- Ingest customer replies from a verified webhook or support workflow.
+- Replace `SafeMemory`'s continue-without-memory policy with a human handoff or closed failure when duplicate contact is unacceptable.
+- Confirm notification behavior in your own Razorpay test-mode account before contacting a real customer.
+- Store Kora and Razorpay credentials in your secret manager, not in the repository or image.
+- Route disputes and exhausted contact attempts into a real human queue.
+- Monitor the audit log, Kora request failures, and the difference between selected actions and successful notifications.
+
+The complete implementation and its policy tests are documented in the [example README](https://github.com/NarayanaSabari/Kora/tree/main/examples/receivables-chaser).
+For the reusable memory pattern, return to [Integrate Kora with an agent](agent-integration.md).


### PR DESCRIPTION
## Summary

- add a framework-neutral guide for MCP, Python, and REST agent integrations
- document the receivables chaser as the canonical Razorpay agent tutorial
- add both guides to website navigation and README discovery
- correct the SDK installation command and a stale operations metric

## Verification

- `pnpm run check`
- `pnpm run links`
- `python3 -m pytest -q` in `examples/receivables-chaser`
- recorded agent reproduced 216 baseline messages and INR 633,300 recovered