### PR TITLE
chore: prepare v0.1.1 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -241,6 +241,10 @@ jobs:
         working-directory: release-assets
         run: sha256sum * > SHA256SUMS
 
+      - name: Normalize version
+        id: version
+        run: echo "number=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -269,12 +273,12 @@ jobs:
 
             **Helm:**
             ```bash
-            helm install kora oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/kora --version ${{ github.ref_name }}
+            helm install kora oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/kora --version ${{ steps.version.outputs.number }}
             ```
 
             **Docker:**
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/kora-server:${{ github.ref_name }}
+            docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/kora-server:${{ steps.version.outputs.number }}
             ```
 
             **CLI:**
@@ -282,5 +286,5 @@ jobs:
 
             **Python SDK:**
             ```bash
-            pip install kora==${{ github.ref_name }}
+            pip install ./kora-${{ steps.version.outputs.number }}-py3-none-any.whl
             ```

--- a/charts/kora/Chart.yaml
+++ b/charts/kora/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kora
 description: Kubernetes-native memory engine for AI agents
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 keywords:
   - ai
   - memory

--- a/mcp-server/kora_mcp/__init__.py
+++ b/mcp-server/kora_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Kora MCP Server — memory engine for any MCP-compatible AI agent."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kora-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for Kora — memory engine for AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,42 @@
+# Kora Python SDK
+
+The dependency-free Python client for the Kora memory engine.
+It uses Kora's REST gateway to store, query, connect, and delete memories, inspect graph context, manage sessions, and check engine health.
+
+## Install
+
+Until the SDK is published to PyPI, download the wheel from the matching [Kora GitHub Release](https://github.com/NarayanaSabari/Kora/releases) and install it locally:
+
+```bash
+pip install ./kora-0.1.1-py3-none-any.whl
+```
+
+To work from a repository clone instead:
+
+```bash
+pip install ./sdk/python
+```
+
+## Use
+
+```python
+from kora import KoraClient
+
+client = KoraClient(
+    endpoint="localhost:50051",
+    api_key="your-key",
+    project="my-project",
+)
+
+client.store(
+    "The project uses PostgreSQL 18.",
+    type="semantic",
+    tags=["database"],
+)
+
+for result in client.query("Which database does this project use?", top_k=3):
+    print(result.score, result.memory.content)
+```
+
+Kora must already be running and reachable from the client.
+See the [Kora documentation](https://kora.sabarinarayana.com/docs/) for installation, authentication, memory types, project scoping, and agent integration.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kora"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for Kora — memory engine for AI agents"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = []
 

--- a/sdk/python/src/kora/__init__.py
+++ b/sdk/python/src/kora/__init__.py
@@ -2,5 +2,5 @@
 
 from kora.client import KoraClient, SessionAlreadyEndedError
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __all__ = ["KoraClient", "SessionAlreadyEndedError"]

--- a/site/404.html
+++ b/site/404.html
@@ -8,7 +8,7 @@
     <title>Page not found - kora</title>
     <meta
       name="description"
-      content="This page does not exist. kora is an open-source memory engine for AI agents, currently in development."
+      content="This page does not exist. kora is an open-source memory engine for AI agents."
     />
     <link rel="canonical" href="https://kora.sabarinarayana.com/" />
     <!-- An error page must never be indexed in place of real content. -->

--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
     <title>kora - Memory for AI agents</title>
     <meta
       name="description"
-      content="kora is an open-source memory engine for AI agents. It remembers what matters across sessions, understands how memories relate, and runs on your own infrastructure. Join the waitlist."
+      content="kora is an open-source memory engine for AI agents. It remembers what matters across sessions, understands how memories relate, and runs on your own infrastructure. v0.1.1 is available."
     />
     <link rel="canonical" href="https://kora.sabarinarayana.com/" />
 

--- a/site/public/docs/README.md
+++ b/site/public/docs/README.md
@@ -6,7 +6,7 @@ Every agent framework has the same hole in it: agents are amnesiac. A session en
 
 kora is a memory engine that closes that hole. Feed it conversations, and it extracts what is worth keeping, stores it as a graph of typed memories, and gives it back when it is relevant. It runs in your own cluster, on PostgreSQL, and every dependency is OSI-approved open source.
 
-> **kora is pre-release.** The engine, the API, the Helm chart, and the Python SDK all work today, and the pages here describe what actually ships. The API is not frozen: it may change before 1.0. [Join the waitlist](/) to be told when it does.
+> **kora is pre-1.0.** Release v0.1.1 is available, and these pages describe what ships in it. The API is not frozen and may change before 1.0, so pin the version and read the release notes before upgrading.
 
 ## What makes it different
 

--- a/site/public/docs/faq.md
+++ b/site/public/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Is kora ready to use?
 
-It runs, and everything documented here works. It is pre-1.0 and the API may still change, so pin a version and read release notes before upgrading. [Join the waitlist](/) to be told when the first release lands.
+Release v0.1.1 is available, and everything documented here works. It is pre-1.0 and the API may still change, so pin the version and read release notes before upgrading.
 
 ## How is this different from a vector database?
 

--- a/site/releases/index.html
+++ b/site/releases/index.html
@@ -8,7 +8,7 @@
     <title>Releases - kora</title>
     <meta
       name="description"
-      content="Every kora release, with its changes and versioning policy. No releases have been cut yet - join the waitlist to hear about the first one."
+      content="Download kora v0.1.1, the self-hosted memory engine for AI agents, and read its installation and upgrade notes."
     />
     <link rel="canonical" href="https://kora.sabarinarayana.com/releases/" />
 

--- a/site/scripts/verify-site.mjs
+++ b/site/scripts/verify-site.mjs
@@ -115,7 +115,7 @@ const base = `http://localhost:${server.address().port}`
 // this loop would assert things that are true of every page except that one.
 const PAGES = [
   { url: '/', name: 'home', heading: /forgets/i },
-  { url: '/releases/', name: 'releases', heading: /releases/i },
+  { url: '/releases/', name: 'releases', heading: /v0\.1\.1/i },
   { url: '/blog/', name: 'blog', heading: /kora/i },
 ]
 const WIDTHS = [
@@ -571,15 +571,22 @@ for (const page of PAGES) {
     )
   }
 
-  // Every React page must offer the waitlist, since that is the site's one
-  // goal. /docs/ is excluded: it is docsify, and its job is documentation.
-  for (const path of ['/releases/', '/blog/']) {
+  // The blog still offers release updates while it has no posts. The release
+  // page now has a direct download instead; asking both pages for a waitlist
+  // would preserve an empty-state requirement after the empty state is gone.
+  for (const path of ['/blog/']) {
     await tab.goto(`${base}${path}`, { waitUntil: 'networkidle' })
     note(
       (await tab.locator('input[type="email"]').count()) > 0,
       `${path} has no waitlist signup`,
     )
   }
+
+  await tab.goto(`${base}/releases/`, { waitUntil: 'networkidle' })
+  note(
+    (await tab.locator('a[href$="/releases/tag/v0.1.1"]').count()) > 0,
+    '/releases/ has no v0.1.1 download link',
+  )
 
   // The hero demo toggle must actually change what is on screen.
   await tab.goto(`${base}/`, { waitUntil: 'networkidle' })

--- a/site/src/components/Waitlist.tsx
+++ b/site/src/components/Waitlist.tsx
@@ -39,7 +39,7 @@ export function Waitlist({ id = 'waitlist', onDark = false }: { id?: string; onD
         '[kora] WAITLIST_ENDPOINT is not set in src/config.ts, so this signup was not stored anywhere.',
       )
       setStatus('error')
-      setMessage('Signups are not open yet. Watch the repository and you will not miss the release.')
+      setMessage('Signups are not open yet. Watch the repository for release updates.')
       return
     }
 
@@ -74,7 +74,7 @@ export function Waitlist({ id = 'waitlist', onDark = false }: { id?: string; onD
           You are on the list.
         </p>
         <p className={`mt-1.5 text-sm ${onDark ? 'text-on-emphasis/75' : 'text-muted'}`}>
-          One email when kora ships. Nothing else, ever.
+          You will hear about kora releases. Nothing else, ever.
         </p>
       </div>
     )
@@ -147,7 +147,7 @@ export function Waitlist({ id = 'waitlist', onDark = false }: { id?: string; onD
             </a>
           </>
         ) : (
-          'One email when it ships. No newsletter, no sharing your address.'
+          'Release updates only. No newsletter, no sharing your address.'
         )}
       </p>
     </div>

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -12,7 +12,7 @@ export const site = {
   url: 'https://kora.sabarinarayana.com',
   tagline: 'Memory for AI agents',
   description:
-    'kora is an open-source memory engine for AI agents. Graph-first, self-hosted, Apache 2.0. Join the waitlist.',
+    'kora is an open-source memory engine for AI agents. Graph-first, self-hosted, Apache 2.0. v0.1.1 is available.',
   // The repository was renamed to Kora alongside the product. GitHub keeps
   // redirecting the old Context0 URL, but a redirect breaks the moment someone
   // else claims that name, so this points at the real current location.

--- a/site/src/pages/Home.tsx
+++ b/site/src/pages/Home.tsx
@@ -9,10 +9,9 @@ import { site } from '../config'
  * The home page.
  *
  * Deliberately an overview, not a product tour. No API reference, no install
- * commands, no architecture diagram, no endpoint tables. kora is not
- * released yet, so the job of this page is to explain the idea clearly enough
- * that the right person joins the waitlist. Depth belongs in the docs once
- * there is something to document.
+ * commands, no architecture diagram, no endpoint tables. The job of this page
+ * is to explain the idea clearly enough that the right person tries the
+ * release. Depth belongs in the docs.
  *
  * The order is an argument, not a list of features:
  *
@@ -67,7 +66,7 @@ export function Home() {
           <div className="min-w-0">
             <p className="t-label mb-7 inline-flex items-center gap-2.5 text-heading">
               <span className="h-1.5 w-1.5 rounded-full bg-emphasis" aria-hidden="true" />
-              In development - Apache 2.0
+              v0.1.1 available - Apache 2.0
             </p>
 
             <h1 className="t-display optical-left">
@@ -187,11 +186,11 @@ export function Home() {
           <div className="on-emphasis reveal relative overflow-hidden rounded-3xl bg-emphasis px-7 py-16 sm:px-14">
             <div className="relative">
               <h2 className="t-title optical-left max-w-xl text-on-emphasis">
-                Be there when it ships.
+                Follow what ships next.
               </h2>
               <p className="mt-5 max-w-lg text-[length:var(--text-lead)] leading-relaxed text-on-emphasis/75">
-                kora is being built in the open. Join the waitlist for one email when the
-                first release lands, or follow along on{' '}
+                kora is built in the open. Join the list for release updates, or follow
+                development on{' '}
                 <a
                   href={site.github}
                   target="_blank"

--- a/site/src/pages/Releases.tsx
+++ b/site/src/pages/Releases.tsx
@@ -1,28 +1,27 @@
 import { Page } from '../components/Chrome'
-import { PageHeader, EmptyState, ButtonLink } from '../components/PageParts'
-import { Waitlist } from '../components/Waitlist'
+import { PageHeader, ButtonLink } from '../components/PageParts'
 import { site } from '../config'
 
 /**
  * Releases.
  *
- * There is no released version yet, and inventing a "v0.1.0" to fill the page
- * would be a lie with a version number on it. The page explains what will be
- * published here and how releases will be numbered, which is genuinely useful
- * to someone deciding whether to depend on this later.
+ * This page is maintained deliberately rather than generated from GitHub.
+ * It gives a reader the short, product-level release summary; GitHub remains
+ * the source for artifacts, checksums, and the complete commit list.
  */
 export function Releases() {
   return (
     <Page current="/releases/">
       <PageHeader
         eyebrow="Releases"
-        title="No releases yet."
+        title="v0.1.1 is available."
         intro={
           <>
-            kora has not cut its first release. When it does, every version will be
-            listed here with its changes, and published on{' '}
+            The first public kora release packages the engine, CLI, Helm chart,
+            container images, Python SDK, and MCP server. Artifacts and checksums are
+            published on{' '}
             <a
-              href={`${site.github}/releases`}
+              href={`${site.github}/releases/tag/v0.1.1`}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex min-h-6 items-center text-heading underline decoration-heading/40 underline-offset-4 transition-colors hover:decoration-heading"
@@ -36,20 +35,56 @@ export function Releases() {
 
       <section>
         <div className="mx-auto max-w-4xl px-6 py-[var(--space-section-tight)]">
-          <EmptyState
-            title="Nothing to download yet"
-            body="The first release will land when the core is stable enough to be worth your time. Join the waitlist and you will hear about it the day it ships."
-            action={
-              <>
-                <ButtonLink href={site.github} external>
-                  Watch the repository
-                </ButtonLink>
-                <ButtonLink href="/docs/" variant="secondary">
-                  Read the docs
-                </ButtonLink>
-              </>
-            }
-          />
+          <article className="rounded-2xl border border-line-bright bg-surface-2/60 p-7 sm:p-9">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="font-mono text-[11px] uppercase tracking-[0.1em] text-dim">
+                  Latest release
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold tracking-[var(--tracking-tight)]">
+                  kora v0.1.1
+                </h2>
+              </div>
+              <time className="font-mono text-xs text-dim" dateTime="2026-09-05">
+                5 September 2026
+              </time>
+            </div>
+
+            <p className="mt-6 max-w-2xl text-[15px] leading-relaxed text-muted">
+              A self-hosted memory engine for AI agents, with graph and vector retrieval,
+              conversation extraction, project profiles, operational tooling, and a
+              measurable Razorpay receivables agent.
+            </p>
+
+            <ul className="mt-7 grid gap-3 text-[14px] leading-relaxed text-body sm:grid-cols-2">
+              {[
+                'REST and gRPC APIs with hashed API-key authentication',
+                'Hybrid full-text, vector, and graph retrieval',
+                'Helm chart, backups, metrics, and production probes',
+                'CLI binaries, Python SDK artifact, and MCP server',
+                'Docker images for the API, web UI, and PostgreSQL stack',
+                'Agent integration and Razorpay example documentation',
+              ].map((item) => (
+                <li key={item} className="rounded-lg border border-line bg-surface px-4 py-3">
+                  {item}
+                </li>
+              ))}
+            </ul>
+
+            <p className="mt-7 max-w-2xl text-[14px] leading-relaxed text-muted">
+              This pre-1.0 release includes the Context0 to Kora rename. Existing
+              deployments must follow the migration notes before upgrading.
+            </p>
+
+            <div className="mt-7 flex flex-wrap gap-3">
+              <ButtonLink href={`${site.github}/releases/tag/v0.1.1`} external>
+                Download v0.1.1
+              </ButtonLink>
+              <ButtonLink href="/docs/#/installation" variant="secondary">
+                Installation guide
+              </ButtonLink>
+            </div>
+          </article>
 
           <div className="mt-16 border-t border-line pt-12">
             <h2 className="text-lg font-semibold tracking-[var(--tracking-tight)]">How versions will work</h2>
@@ -61,7 +96,7 @@ export function Releases() {
 
             <dl className="mt-9 grid gap-px overflow-hidden rounded-xl border border-line bg-line sm:grid-cols-3">
               {[
-                ['Patch', 'Fixes only. Always safe to take.'],
+                ['Patch', 'Fixes and hardening. Review upgrade notes before 1.0.'],
                 ['Minor', 'New capability. Before 1.0, may break something.'],
                 ['Major', 'Reserved for 1.0 and the stability promise that comes with it.'],
               ].map(([label, body]) => (
@@ -75,15 +110,6 @@ export function Releases() {
             </dl>
           </div>
 
-          <div className="mt-16 border-t border-line pt-12">
-            <h2 className="text-lg font-semibold tracking-[var(--tracking-tight)]">Know when the first one lands</h2>
-            <p className="mt-3 max-w-xl text-[15px] leading-relaxed text-muted">
-              One email, on release day.
-            </p>
-            <div className="mt-7">
-              <Waitlist id="releases" />
-            </div>
-          </div>
         </div>
       </section>
     </Page>

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- bump the Helm chart, Python SDK, MCP server, and product web UI to 0.1.1
- replace the website release empty state with the v0.1.1 release page
- update website and docs language now that a release is available
- correct generated Helm, Docker, and Python installation commands
- add the missing Python SDK package readme

## Verification

- `go test ./... -race -count=1`
- `pnpm run build` in `web`
- `pnpm run check` in `site`
- Helm lint and package produced `kora-0.1.1.tgz`
- Python sdist and wheel built; installed wheel reports `0.1.1`
- release workflow dry run dispatched for this branch

## Release note

`CHANGELOG.md` is unchanged. The release workflow generates GitHub release notes from the commit history.