### PR TITLE
fix(site): redirect removed blog route

### DIFF
--- a/site/public/_redirects
+++ b/site/public/_redirects
@@ -1,0 +1,3 @@
+# The Blog has been removed.
+# Keep old bookmarks and cached links away from the deleted page.
+/blog/* /releases/ 301

--- a/site/scripts/check-build.mjs
+++ b/site/scripts/check-build.mjs
@@ -52,6 +52,16 @@ const PAGES = [
   { path: 'releases/index.html', url: '/releases/', title: /Releases/ },
 ]
 
+const redirectsPath = join(dist, '_redirects')
+check(existsSync(redirectsPath), 'dist/_redirects is missing')
+if (existsSync(redirectsPath)) {
+  const redirects = readFileSync(redirectsPath, 'utf8')
+  check(
+    redirects.includes('/blog/* /releases/ 301'),
+    '_redirects must permanently redirect the removed Blog to Releases',
+  )
+}
+
 // The 404 is checked separately: Pages serves it for unmatched paths, so it
 // has no canonical URL of its own and must not be indexed.
 const NOT_FOUND = '404.html'


### PR DESCRIPTION
## Summary

- permanently redirect legacy `/blog/` URLs to the v0.1.1 release page
- verify the redirect is present in every production build
- prevent stale Blog content from remaining reachable after the page removal

## Verification

- `cd site && pnpm run build`
- `cd site && node scripts/check-build.mjs`